### PR TITLE
Update input collections, rebased

### DIFF
--- a/BParkingNano/plugins/ElectronMerger.cc
+++ b/BParkingNano/plugins/ElectronMerger.cc
@@ -15,17 +15,29 @@
 #include <algorithm>
 
 class ElectronMerger : public edm::global::EDProducer<> {
+
+  // perhaps we need better structure here (begin run etc)
+
+
 public:
+
   explicit ElectronMerger(const edm::ParameterSet &cfg):
     triggerMuons_{ consumes<pat::MuonCollection>( cfg.getParameter<edm::InputTag>("trgMuon") )},
     lowpt_src_{ consumes<pat::ElectronCollection>( cfg.getParameter<edm::InputTag>("lowptSrc") )},
     pf_src_{ consumes<pat::ElectronCollection>( cfg.getParameter<edm::InputTag>("pfSrc") )},
+    ptBiased_src_{ consumes<edm::ValueMap<float>>( cfg.getParameter<edm::InputTag>("ptbiasedSeeding") )},
+    unBiased_src_{ consumes<edm::ValueMap<float>>( cfg.getParameter<edm::InputTag>("unbiasedSeeding") )},
+    mvaId_src_{ consumes<edm::ValueMap<float>>( cfg.getParameter<edm::InputTag>("mvaId") )},
     drTrg_cleaning_{cfg.getParameter<double>("drForCleaning_wrtTrgMuon")},
     dzTrg_cleaning_{cfg.getParameter<double>("dzForCleaning_wrtTrgMuon")},
     dr_cleaning_{cfg.getParameter<double>("drForCleaning")},
     dz_cleaning_{cfg.getParameter<double>("dzForCleaning")},
-    use_gsf_mode_for_p4_{cfg.getParameter<bool>("useGsfModeForP4")} {
-      produces<pat::ElectronCollection>();
+    ptMin_{cfg.getParameter<double>("ptMin")},
+    etaMax_{cfg.getParameter<double>("etaMax")},
+    bdtMin_{cfg.getParameter<double>("bdtMin")},
+    use_gsf_mode_for_p4_{cfg.getParameter<bool>("useGsfModeForP4")} 
+    {
+       produces<pat::ElectronCollection>("SelectedElectrons");
     }
 
   ~ElectronMerger() override {}
@@ -38,93 +50,134 @@ private:
   const edm::EDGetTokenT<pat::MuonCollection> triggerMuons_;
   const edm::EDGetTokenT<pat::ElectronCollection> lowpt_src_;
   const edm::EDGetTokenT<pat::ElectronCollection> pf_src_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> ptBiased_src_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> unBiased_src_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> mvaId_src_;
   const double drTrg_cleaning_;
   const double dzTrg_cleaning_;
   const double dr_cleaning_;
   const double dz_cleaning_;
+  const double ptMin_; //pt min cut
+  const double etaMax_; //eta max cut
+  const double bdtMin_; //bdt min cut
   const bool use_gsf_mode_for_p4_;
 };
 
 void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup const &) const {
 
+  //input
   edm::Handle<pat::MuonCollection> trgMuon;
   evt.getByToken(triggerMuons_, trgMuon);
-
   edm::Handle<pat::ElectronCollection> lowpt;
   evt.getByToken(lowpt_src_, lowpt);
-
   edm::Handle<pat::ElectronCollection> pf;
   evt.getByToken(pf_src_, pf);
+  edm::Handle<edm::ValueMap<float> > ptBiased;
+  evt.getByToken(ptBiased_src_, ptBiased);
+  edm::Handle<edm::ValueMap<float> > unBiased;
+  evt.getByToken(unBiased_src_, unBiased);
+  edm::Handle<edm::ValueMap<float> > mvaId;  
+  evt.getByToken(mvaId_src_, mvaId);
+
+  // output
+  std::unique_ptr<pat::ElectronCollection> ele_out(new pat::ElectronCollection);
+
   
-  std::unique_ptr<pat::ElectronCollection> out(new pat::ElectronCollection);
+  // -> changing order of loops ert Arabella's fix this without need for more vectors  
+ for(auto ele : *pf) {
+   //cuts
+   if (ele.pt()<ptMin_) continue;
+   if (fabs(ele.eta())>etaMax_) continue;
+   // apply conversion veto unless we want conversions
+   if (!ele.passConversionVeto()) continue;
 
-  //just to avoid electrons double storing
-  //in case of ntrgMuon > 1 and same electron compatible with all 
-  std::vector<int> alreadySavedPF;
-  alreadySavedPF.resize(pf->size(), 0);
+   // skip electrons inside tag's jet or from different PV
+   bool skipEle=true;
+   for(const auto & trg : *trgMuon) {
+     if(reco::deltaR(ele, trg) < drTrg_cleaning_ && drTrg_cleaning_ > 0)
+        continue;
+     if(fabs(ele.vz() - trg.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ > 0)
+        continue;
+     skipEle=false;
+     break; // one trg muon to pass is enough :)
+   }
+   // we skip evts without trg muon
+   if (skipEle) continue;
 
-  std::vector<int> alreadySavedLPT;
-  alreadySavedLPT.resize(lowpt->size(), 0);
+   // for PF e we set BDT outputs to much higher number than the max
+   ele.addUserInt("isPF", 1);
+   ele.addUserInt("isLowPt", 0);
+   ele.addUserFloat("ptBiased", 20.);
+   ele.addUserFloat("unBiased", 20.);
+   ele.addUserFloat("mvaId", 20);
+   ele.addUserFloat("chargeMode", ele.charge());
+   ele_out->emplace_back(ele);
+ }
 
-  for(auto muonTrg : *trgMuon) {
 
-    int icount = -1;
-    for(auto ele : *pf) {
-      ++icount;
-      if(alreadySavedPF[icount]) continue;
+ size_t iele=-1;
+ /// add and clean low pT e
+  for(auto ele : *lowpt) {
+    iele++;
+    //take modes
+   if(use_gsf_mode_for_p4_) {
+     reco::Candidate::PolarLorentzVector p4( ele.gsfTrack()->ptMode(),
+                                             ele.gsfTrack()->etaMode(),
+                                             ele.gsfTrack()->phiMode(),
+                                             ele.mass()    );
+     ele.setP4(p4);
+   }
 
-      if((reco::deltaR(ele, muonTrg) < drTrg_cleaning_ && drTrg_cleaning_ != -1) ||
-	 (std::fabs(ele.vz() - muonTrg.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ != -1)) continue;
+   //same cuts as in PF
+   if (ele.pt()<ptMin_) continue;
+   if (fabs(ele.eta())>etaMax_) continue;
+   // apply conversion veto?
+   if (!ele.passConversionVeto()) continue;
 
-      ele.addUserInt("isPF", 1);
-      ele.addUserInt("isLowPt", 0);
-      ele.addUserFloat("ptBiased", 20.);
-      ele.addUserFloat("unBiased", 20.);
-      ele.addUserFloat("mvaId", 20.);
-      ele.addUserFloat("chargeMode", ele.charge());
-      alreadySavedPF[icount] = 1;
-      out->push_back(ele);
-    }
+   //assigning BDT values
+   const reco::GsfTrackRef gsfTrk = ele.gsfTrack();
+   float unbiased_seedBDT = float((*unBiased)[gsfTrk]);
+   float ptbiased_seedBDT = float((*ptBiased)[gsfTrk]);
+   if ( unbiased_seedBDT <bdtMin_) continue; //extra cut for low pT e on BDT
 
-    icount = -1;
-    for(auto ele : *lowpt) {
-      ++icount;
-      if(alreadySavedLPT[icount]) continue;
+   bool skipEle=true;
+   for(const auto & trg : *trgMuon) {
+     if(reco::deltaR(ele, trg) < drTrg_cleaning_ && drTrg_cleaning_ > 0)
+        continue;
+     if(fabs(ele.vz() - trg.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ > 0)
+        continue;
+     skipEle=false;
+     break;  // one trg muon is enough 
+   }
+   // same here Do we need evts without trg muon? now we skip them
+   if (skipEle) continue;   
 
-      if((reco::deltaR(ele, muonTrg) < drTrg_cleaning_ && drTrg_cleaning_ != -1) ||
-	 (std::fabs(ele.vz() - muonTrg.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ != -1)) continue;
+   //pf cleaning    
+   bool clean_out = false;
+   for(const auto& pfele : *pf) {
+      clean_out |= (
+	           fabs(pfele.vz() - ele.vz()) < dz_cleaning_ &&
+                   reco::deltaR(ele, pfele) < dr_cleaning_   );
+   }
+   if(clean_out) continue;
+   edm::Ref<pat::ElectronCollection> ref(lowpt,iele);
+   float mva_id = float((*mvaId)[ref]);
+   ele.addUserInt("isPF", 0);
+   ele.addUserInt("isLowPt", 1);
+   ele.addUserFloat("chargeMode", ele.gsfTrack()->chargeMode());
+   ele.addUserFloat("ptBiased", ptbiased_seedBDT);
+   ele.addUserFloat("unBiased", unbiased_seedBDT);
+   ele.addUserFloat("mvaId", mva_id);
+   ele_out->emplace_back(ele);
+ }
 
-      bool clean_out = false;
-      for(const auto& pfele : *pf) {
-
-	clean_out |= (
-		      fabs(pfele.vz() - ele.vz()) < dz_cleaning_ &&
-		      reco::deltaR(ele, pfele) < dr_cleaning_
-		      );
-      }
-      if(clean_out) continue;
-      ele.addUserInt("isPF", 0);
-      ele.addUserInt("isLowPt", 1);
-      ele.addUserFloat("chargeMode", ele.gsfTrack()->chargeMode());
-      if(use_gsf_mode_for_p4_) {
-	reco::Candidate::PolarLorentzVector p4(
-					     ele.gsfTrack()->ptMode(),
-					     ele.gsfTrack()->etaMode(),
-					     ele.gsfTrack()->phiMode(),
-					     ele.mass()
-					     );
-	ele.setP4(p4);
-      }
-      alreadySavedLPT[icount] = 1;
-      out->push_back(ele);
-    }
-
-    std::sort(
-	      out->begin(), out->end(), 
-	      [] (pat::Electron e1, pat::Electron e2) -> bool {return e1.pt() > e2.pt();}
+//is this nescaisery ? because it is additional loop
+   /* std::sort( out->begin(), out->end(), [] (pat::Electron e1, pat::Electron e2) -> bool {return e1.pt() > e2.pt();}
 	      );
-  }
-  evt.put(std::move(out));
+  }*/
+
+  //adding label to be consistent with the muon and track naming
+  evt.put(std::move(ele_out),"SelectedElectrons");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/BParkingNano/plugins/TrackMerger.cc
+++ b/BParkingNano/plugins/TrackMerger.cc
@@ -13,35 +13,39 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
-#include "helper.h"
+#include "DataFormats/Common/interface/AssociationVector.h"
 
 
 class TrackMerger : public edm::global::EDProducer<> {
+
+
 public:
+
+  //would it be useful to give this a bit more standard structure?
   explicit TrackMerger(const edm::ParameterSet &cfg):
-    //beamSpotSrc_( consumes<reco::BeamSpot> (cfg.getParameter<edm::InputTag>("beamSpot"))),
     tracksToken_(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("tracks"))),
     lostTracksToken_(consumes<pat::PackedCandidateCollection>(cfg.getParameter<edm::InputTag>("lostTracks"))),
     trgMuonToken_(consumes<pat::MuonCollection>(cfg.getParameter<edm::InputTag>("trgMuon"))),
     trkPtCut_(cfg.getParameter<double>("trkPtCut")),
     trkEtaCut_(cfg.getParameter<double>("trkEtaCut")),
     dzTrg_cleaning_(cfg.getParameter<double>("dzTrg_cleaning")),
-    drTrg_ProbeCleaning_(cfg.getParameter<double>("drTrg_ProbeCleaning")),
-    drTrg_TagCleaning_(cfg.getParameter<double>("drTrg_TagCleaning")),
-    dcaSig_probe_(cfg.getParameter<double>("dcaSig_probe")),
-    dcaSig_tag_(cfg.getParameter<double>("dcaSig_tag")),
+  //  drTrg_ProbeCleaning_(cfg.getParameter<double>("drTrg_ProbeCleaning")),
+  //  drTrg_TagCleaning_(cfg.getParameter<double>("drTrg_TagCleaning")),
+  //  dcaSig_probe_(cfg.getParameter<double>("dcaSig_probe")),
+  //  dcaSig_tag_(cfg.getParameter<double>("dcaSig_tag")),
+    drTrg_Cleaning_(cfg.getParameter<double>("drTrg_Cleaning")),
+    dcaSig_(cfg.getParameter<double>("dcaSig")),
     trkNormChiMin_(cfg.getParameter<int>("trkNormChiMin")),
     trkNormChiMax_(cfg.getParameter<int>("trkNormChiMax")) 
 {
-    produces<pat::CompositeCandidateCollection>("TagSide");
-    produces<pat::CompositeCandidateCollection>("ProbeSide");
+  // removed until we see the plot
+//    produces<pat::CompositeCandidateCollection>("TagSide");
+    produces<pat::CompositeCandidateCollection>("SelectedTracks");  
 }
 
   ~TrackMerger() override {}
@@ -53,127 +57,120 @@ public:
 				      const GlobalPoint& refP) const;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {}
+  
 
 private:
-  //  const edm::EDGetTokenT<reco::BeamSpot> beamSpotSrc_;
+
   const edm::EDGetTokenT<pat::PackedCandidateCollection> tracksToken_;
   const edm::EDGetTokenT<pat::PackedCandidateCollection> lostTracksToken_;
   const edm::EDGetTokenT<pat::MuonCollection> trgMuonToken_;
 
   //selections                                                                 
-  const double trkPtCut_;
-  const double trkEtaCut_;
-  const double dzTrg_cleaning_;
-  const double drTrg_ProbeCleaning_;
-  const double drTrg_TagCleaning_;
-  const double dcaSig_probe_;
-  const double dcaSig_tag_;
-  const int trkNormChiMin_;
+  const double trkPtCut_;                const double trkEtaCut_;
+  const double dzTrg_cleaning_;          const double drTrg_Cleaning_;
+  // untill the study for this finalized, perhaps we keep it as comment. Then we uncomment it
+ // const double drTrg_ProbeCleaning_;   const double drTrg_TagCleaning_;
+ // const double dcaSig_probe_;         const double dcaSig_tag_;
+  const double dcaSig_;                  const int trkNormChiMin_;
   const int trkNormChiMax_;
 };
 
+
+
+
+
+
 void TrackMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup const &stp) const {
-  //get data  
+
+  //input
   edm::ESHandle<MagneticField> bFieldHandle;
   stp.get<IdealMagneticFieldRecord>().get(bFieldHandle);
-  // edm::Handle<reco::BeamSpot> beamSpotHandle;  
-  // evt.getByToken(beamSpotSrc_, beamSpotHandle);
-  // if ( ! beamSpotHandle.isValid() ) {
-  //   edm::LogError("PFCandProducer") << "No beam spot available from EventSetup" ;
-  // }
-  // reco::BeamSpot beamSpot = *beamSpotHandle;
-
   edm::Handle<pat::PackedCandidateCollection> tracks;
   evt.getByToken(tracksToken_, tracks);
-  
   edm::Handle<pat::PackedCandidateCollection> lostTracks;
   evt.getByToken(lostTracksToken_, lostTracks);
-  
-  edm::Handle<pat::MuonCollection> trgMuon;
-  evt.getByToken(trgMuonToken_, trgMuon);
+  edm::Handle<pat::MuonCollection> trgMuons;
+  evt.getByToken(trgMuonToken_, trgMuons);
 
-  int nTracks = tracks->size();
-  int nLostTracks = lostTracks->size();      
-  int totalTracks = nTracks + nLostTracks;
+  //for lost tracks / pf discrimination
+  unsigned int nTracks = tracks->size();
+
+ // do we need all those ints?
+//  int nLostTracks = lostTracks->size();      
+//  int totalTracks = nTracks + nLostTracks;
+ //same as before comment out untill we are sure 
+//  std::unique_ptr<pat::CompositeCandidateCollection> outTag(new pat::CompositeCandidateCollection());
+
+//ok this was CompositeCandidateCollection 
+  std::unique_ptr<pat::CompositeCandidateCollection> tracks_out(new pat::CompositeCandidateCollection);
+
+
+//correct logic but a bit convoluted -> changing to smthn simpler
+ std::vector<pat::PackedCandidate> totalTracks(*tracks);
+
+ totalTracks.insert(totalTracks.end(),lostTracks->begin(),lostTracks->end());
+
  
-  std::unique_ptr<pat::CompositeCandidateCollection> outTag(new pat::CompositeCandidateCollection());
-  std::unique_ptr<pat::CompositeCandidateCollection> outProbe(new pat::CompositeCandidateCollection());
+ // for loop is better to be range based - especially for large ensembles  
+ for( const pat::PackedCandidate & trk: totalTracks){
 
+   //arranging cuts for speed
+   if(!trk.hasTrackDetails()) continue;
+   if(abs(trk.pdgId()) != 211) continue; //do we want also to keep muons?
+   if(trk.pt() < trkPtCut_ ) continue;
+   if(fabs(trk.eta()) > trkEtaCut_) continue;
 
-  std::vector<int> alreadySaved;
-  alreadySaved.resize(totalTracks, 0);
+   if( (trk.pseudoTrack().normalizedChi2() < trkNormChiMin_ &&
+        trkNormChiMin_>=0 ) ||
+       (trk.pseudoTrack().normalizedChi2() > trkNormChiMax_ &&
+        trkNormChiMax_>0)  )    continue; 
 
-  for(auto muonTrg : *trgMuon) {
+   bool skipTrack=true;
+   GlobalPoint trgvtx;
+   for (const pat::Muon & mu: *trgMuons){
+    //remove tracks inside trg muons jet
+    if(reco::deltaR(trk, mu) < drTrg_Cleaning_ && drTrg_Cleaning_ >0) 
+      continue;
+    //if dz is negative it is deactivated
+    if((fabs(trk.vz() - mu.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ > 0))
+       continue;
+    skipTrack=false;
+    trgvtx=GlobalPoint(mu.vx(),mu.vy(),mu.vz());
+    break; // at least for one trg muon to pass this cuts
+   }
+   // if track is closer to at least a triggering muon keep it
+   if (skipTrack) continue;
 
-    for(int iTrk=0; iTrk<totalTracks; ++iTrk){
-
-      const pat::PackedCandidate* trk;
-
-      if(iTrk < nTracks){
-	if(alreadySaved[iTrk]) continue;
-	trk = &((*tracks)[iTrk]);
-	if(!trk->trackHighPurity()) continue;
-	if(abs(trk->pdgId()) != 211 && abs(trk->pdgId()) != 13) continue;
-      }
-      else{
-	if(alreadySaved[iTrk-nTracks]) continue;
-	trk = &((*lostTracks)[iTrk-nTracks]);
-	if(abs(trk->pdgId()) != 211) continue;
-      }
-      if(!trk->hasTrackDetails()) continue;
-      if(trk->pt() < trkPtCut_ || std::fabs(trk->eta()) > trkEtaCut_) continue;
-      if(trk->pseudoTrack().normalizedChi2() < trkNormChiMin_ ||
-	 trk->pseudoTrack().normalizedChi2() > trkNormChiMax_ ) continue;
-      
-      if((std::fabs(trk->vz() - muonTrg.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ != -1)) continue;
-
-      bool saved = false;
-
-      //distance closest approach in x,y wrt triggeringMuon
-      std::pair<double,double> DCA = computeDCA(*trk,
-						bFieldHandle,
-						GlobalPoint(muonTrg.vx(), muonTrg.vy(), muonTrg.vz()));
-      float DCABS = DCA.first;
-      float DCABSErr = DCA.second;
-      float DCASig = DCABS/DCABSErr;
-      
-      //probe side
-      if((drTrg_ProbeCleaning_ == -1 && drTrg_TagCleaning_ == -1) ||
-	 (DCASig > dcaSig_probe_  && (reco::deltaR(*trk, muonTrg) > drTrg_ProbeCleaning_)) ){
-
-	pat::CompositeCandidate pcand;
-	pcand.addDaughter(*trk);
-	pcand.addUserInt("isPacked", (iTrk < nTracks) ? 1 : 0);
-	pcand.addUserInt("isLostTrk", (iTrk < nTracks) ? 0 : 1);
-	pcand.addUserFloat("dxy", trk->dxy());
-	pcand.addUserFloat("dxyS", trk->dxy()/trk->dxyError());
-	pcand.addUserFloat("dz", trk->dz());
-	pcand.addUserFloat("dzS", trk->dz()/trk->dzError());
-	pcand.addUserFloat("DCASig", DCASig);
-	outProbe->push_back(pcand);
-	saved = true;
-      }
-      if((drTrg_ProbeCleaning_ != -1 || drTrg_TagCleaning_ != -1) &&
-	 DCASig < dcaSig_tag_ && (reco::deltaR(*trk, muonTrg) < drTrg_TagCleaning_)){
-
-	pat::CompositeCandidate pcand;
-	pcand.addDaughter(*trk);
-	pcand.addUserInt("isPacked", (iTrk < nTracks) ? 1 : 0);
-	pcand.addUserInt("isLostTrk", (iTrk < nTracks) ? 0 : 1);
-	pcand.addUserFloat("dxy", trk->dxy());
-	pcand.addUserFloat("dxyS", trk->dxy()/trk->dxyError());
-	pcand.addUserFloat("dz", trk->dz());
-	pcand.addUserFloat("dzS", trk->dz()/trk->dzError());
-	pcand.addUserFloat("DCASig", DCASig);
-	outTag->push_back(pcand);
-	saved = true;
-      }    
-      if(saved) alreadySaved[((iTrk < nTracks) ? iTrk : (iTrk - nTracks))] = 1;
-    }
-  }
-
-  evt.put(std::move(outTag), "TagSide");
-  evt.put(std::move(outProbe), "ProbeSide");
+   // high purity requirment applied only in packedCands
+   unsigned int itrk=&trk-&totalTracks[0];
+   if( itrk < nTracks && !trk.trackHighPurity()) continue;
+   
+   //distance closest approach in x,y wrt triggeringMuon
+   std::pair<double,double> DCA = computeDCA(trk, bFieldHandle, trgvtx);
+   float DCABS = DCA.first;
+   float DCABSErr = DCA.second;
+   float DCASig = DCABS/DCABSErr;
+   if (DCASig >  dcaSig_  && dcaSig_ >0) continue;
+   pat::CompositeCandidate pcand;
+   
+   pcand.setP4(trk.p4());
+   pcand.setCharge(trk.charge());
+   pcand.setVertex(trk.vertex());
+   pcand.addUserInt("isPacked", (itrk < nTracks) ? 1 : 0);
+   pcand.addUserInt("isLostTrk", (itrk < nTracks) ? 0 : 1);      
+   pcand.addUserFloat("dxy", trk.dxy());
+   pcand.addUserFloat("dxyS", trk.dxy()/trk.dxyError());
+   pcand.addUserFloat("dz", trk.dz()); 
+   pcand.addUserFloat("dzS", trk.dz()/trk.dzError());
+   pcand.addUserFloat("DCASig", DCASig);
+   //adding the candidate in the composite stuff for fit (need to test)
+//   pcand.addUserCand("cand",trk.sourceCandidatePtr(0));
+    
+   tracks_out->emplace_back(pcand);
+ }
+ 
+//evt.put(std::move(outTag), "TagSide");
+  evt.put(std::move(tracks_out), "SelectedTracks");
 }
 
 

--- a/BParkingNano/plugins/TrackMerger.cc
+++ b/BParkingNano/plugins/TrackMerger.cc
@@ -164,7 +164,10 @@ void TrackMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup const 
    pcand.addUserFloat("dzS", trk.dz()/trk.dzError());
    pcand.addUserFloat("DCASig", DCASig);
    //adding the candidate in the composite stuff for fit (need to test)
-//   pcand.addUserCand("cand",trk.sourceCandidatePtr(0));
+   if ( itrk < nTracks )
+     pcand.addUserCand( "cand", edm::Ptr<pat::PackedCandidate> ( tracks, itrk ));
+   else 
+     pcand.addUserCand( "cand", edm::Ptr<pat::PackedCandidate> ( lostTracks, itrk-nTracks ));
     
    tracks_out->emplace_back(pcand);
  }

--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -1,6 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 
+from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronID_cff import lowPtGsfElectronID
+lowPtGsfElectronLatestID = lowPtGsfElectronID.clone()
+lowPtGsfElectronLatestID.electrons = 'slimmedLowPtElectrons'
+lowPtGsfElectronLatestID.rho = 'fixedGridRhoFastjetAll'
+
 ##essentially the commented out can be inside the same loop... no need to have a more loops in an "expensive" object
 '''lowptElectronsWithSeed = cms.EDProducer(
   'PATLowPtElectronSeedingEmbedder',
@@ -45,7 +50,7 @@ electronsForAnalysis = cms.EDProducer(
   dzForCleaning = cms.double(0.01),
   ptMin = cms.double(1.),
   etaMax = cms.double(2.5),
-  bdtMin = cms.double(15), #this cut can be used to deactivate low pT e if set to >12
+    bdtMin = cms.double(0), #this cut can be used to deactivate low pT e if set to >12
   useGsfModeForP4 = cms.bool(True),
 )
 
@@ -80,6 +85,7 @@ electronBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         isLowPt = Var("userInt('isLowPt')",bool,doc="electron is LowPt candidate"),
         ptBiased = Var("userFloat('ptBiased')",float,doc="ptBiased from seed BDT 20 for pfEle"), 
         unBiased = Var("userFloat('unBiased')",float,doc="unBiased from seed BDT 20 for pfEle"), 
+        mvaId = Var("userFloat('mvaId')",float,doc="MVA ID for low pT, 20 for pfEle"),
         fBrem = Var("fbrem()",float,doc="brem fraction from the gsf fit",precision=8)
         )
 )
@@ -96,6 +102,7 @@ electronsBParkMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, de
     maxDPtRel   = cms.double(0.5),              # Minimum deltaPt/Pt for the match
     resolveAmbiguities    = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
     resolveByMatchQuality = cms.bool(True),    # False = just match input in order; True = pick lowest deltaR pair first
+    
 )
 
 electronBParkMCTable = cms.EDProducer("CandMCMatchTableProducer",
@@ -109,7 +116,8 @@ electronBParkMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 
 electronsBParkSequence = cms.Sequence(
-  electronsForAnalysis
+  lowPtGsfElectronLatestID
+  +electronsForAnalysis
 )
 
 

--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -1,28 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 
-from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronID_cff import lowPtGsfElectronID
-lowPtGsfElectronLatestID = lowPtGsfElectronID.clone()
-lowPtGsfElectronLatestID.electrons = 'slimmedLowPtElectrons'
-lowPtGsfElectronLatestID.rho = 'fixedGridRhoFastjetAll'
-
-lowptElectronsWithSeedAndId = cms.EDProducer(
+##essentially the commented out can be inside the same loop... no need to have a more loops in an "expensive" object
+'''lowptElectronsWithSeed = cms.EDProducer(
   'PATLowPtElectronSeedingEmbedder',
   src = cms.InputTag('slimmedLowPtElectrons'),
   ptbiasedSeeding = cms.InputTag("lowPtGsfElectronSeedValueMaps","ptbiased","RECO"),
   unbiasedSeeding = cms.InputTag("lowPtGsfElectronSeedValueMaps","unbiased","RECO"),
-  mvaId = cms.InputTag("lowPtGsfElectronLatestID"),
     minBdtUnbiased = cms.double(0.5)
 )
-
 lowptElectronsForAnalysis = cms.EDFilter(
   'PATElectronSelector',
-  src = cms.InputTag("lowptElectronsWithSeedAndId"),
+  src = cms.InputTag("lowptElectronsWithSeed"),
   ## need to add cut on BDT and ID when available 
   ## pT > 0.5 to accomodate l1 and l2
   cut = cms.string('pt > 0.5 && eta > -2.4 && eta < 2.4'),
   )
-
 pfElectronsForAnalysis = cms.EDFilter(
   'PATElectronSelector',
   src = cms.InputTag("slimmedElectrons"),
@@ -30,29 +23,39 @@ pfElectronsForAnalysis = cms.EDFilter(
   ## pT > 2 since almost nothing below anyway
   cut = cms.string("pt > 2 && eta > -2.4 && eta < 2.4"),
   )
+'''
 
+
+
+
+#Everything can be done here, in one loop and save time :)
 electronsForAnalysis = cms.EDProducer(
   'ElectronMerger',
-  trgMuon = cms.InputTag('muonTrgSelector:trgMatched'),
-  lowptSrc = cms.InputTag('lowptElectronsForAnalysis'),
-  pfSrc    = cms.InputTag('pfElectronsForAnalysis'),
+  trgMuon = cms.InputTag('muonTrgSelector:trgMuons'),
+  lowptSrc = cms.InputTag('slimmedLowPtElectrons'),
+  pfSrc    = cms.InputTag('slimmedElectrons'),
+  ptbiasedSeeding = cms.InputTag("lowPtGsfElectronSeedValueMaps","ptbiased","RECO"),
+  unbiasedSeeding = cms.InputTag("lowPtGsfElectronSeedValueMaps","unbiased","RECO"),
+  mvaId = cms.InputTag("lowPtGsfElectronLatestID"),
   ## cleaning wrt trigger muon [-1 == no cut]
-  drForCleaning_wrtTrgMuon = cms.double(0.4),
-  dzForCleaning_wrtTrgMuon = cms.double(1.),
+  drForCleaning_wrtTrgMuon = cms.double(-1.),
+  dzForCleaning_wrtTrgMuon = cms.double(-1.),
   ## cleaning between pfEle and lowPtGsf
   drForCleaning = cms.double(0.01),
   dzForCleaning = cms.double(0.01),
+  ptMin = cms.double(1.),
+  etaMax = cms.double(2.5),
+  bdtMin = cms.double(15), #this cut can be used to deactivate low pT e if set to >12
   useGsfModeForP4 = cms.bool(True),
 )
 
-
 electronBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
- src = cms.InputTag("electronsForAnalysis"),
- cut = cms.string(""), #we should not filter on cross linked collections
+ src = cms.InputTag("electronsForAnalysis:SelectedElectrons"),
+ cut = cms.string(""),
     name= cms.string("Electron"),
     doc = cms.string("slimmedElectrons for BPark after basic selection"),
-    singleton = cms.bool(False), # the number of entries is variable
-    extension = cms.bool(False), # this is the main table for the electrons                                                     
+    singleton = cms.bool(False), 
+    extension = cms.bool(False),                                                
     variables = cms.PSet(P4Vars,
         pdgId  = Var("pdgId", int, doc="PDG code assigned by the event reconstruction (not by MC truth)"),
         charge = Var("userFloat('chargeMode')", int, doc="electric charge from pfEle or chargeMode for lowPtGsf"),
@@ -77,7 +80,6 @@ electronBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         isLowPt = Var("userInt('isLowPt')",bool,doc="electron is LowPt candidate"),
         ptBiased = Var("userFloat('ptBiased')",float,doc="ptBiased from seed BDT 20 for pfEle"), 
         unBiased = Var("userFloat('unBiased')",float,doc="unBiased from seed BDT 20 for pfEle"), 
-        mvaId = Var("userFloat('mvaId')",float,doc="MVA ID for low pT, 20 for pfEle"), 
         fBrem = Var("fbrem()",float,doc="brem fraction from the gsf fit",precision=8)
         )
 )
@@ -107,16 +109,11 @@ electronBParkMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 
 electronsBParkSequence = cms.Sequence(
-  (
-    lowPtGsfElectronLatestID *
-    lowptElectronsWithSeedAndId *
-    lowptElectronsForAnalysis +
-    pfElectronsForAnalysis 
-  ) *
   electronsForAnalysis
 )
 
 
 electronBParkMC = cms.Sequence(electronsBParkMCMatchForTable + electronBParkMCTable)
 electronBParkTables = cms.Sequence(electronBParkTable)
+
 

--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 
+
+
 muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
                                  muonCollection = cms.InputTag("slimmedMuons"), #same collection as in NanoAOD                                                           
                                  bits = cms.InputTag("TriggerResults","","HLT"),
@@ -11,16 +13,20 @@ muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
                                  ##for the output matched collection                                                                                                     
                                  maxdR_matching = cms.double(0.01),
                                  
-                                 ## for the output filtered collection                                                                                                   
-                                 # do not cut on dR to keep Kmumu on trg side                                                                                            
+                                 ## for the output filtered collection                                                                                         
                                  dzForCleaning_wrtTrgMuon = cms.double(1.),
+                                 # gives the possibility to run only on probe side - used in other objects
+                                 #deactivated now
+                                 drForCleaning_wrtTrgMuon = cms.double (-1.),
                                  ptMin = cms.double(1.),
-                                 absEtaMax = cms.double(2.4)
+                                 absEtaMax = cms.double(2.4),
+                                 # keeps only muons with at soft Quality flag
+                                 softMuonsOnly = cms.bool(False)
                              )
 
 
 muonBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
-    src = cms.InputTag("muonTrgSelector:trgFiltered"),
+    src = cms.InputTag("muonTrgSelector:SelectedMuons"),
     cut = cms.string(""), #we should not filter on cross linked collections
     name = cms.string("Muon"),
     doc  = cms.string("slimmedMuons for BPark after basic selection"),
@@ -88,7 +94,7 @@ muonBParkMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 
 muonTriggerMatchedTable = muonBParkTable.clone(
-    src = cms.InputTag("muonTrgSelector:trgMatched"),
+    src = cms.InputTag("muonTrgSelector:trgMuons"),
     name = cms.string("TriggerMuon"),
     doc  = cms.string("reco muon matched to triggering muon"),
     variables = cms.PSet(CandVars,
@@ -104,4 +110,3 @@ muonBParkSequence = cms.Sequence(muonTrgSelector)
 muonBParkMC = cms.Sequence(muonsBParkMCMatchForTable + muonBParkMCTable)
 muonBParkTables = cms.Sequence(muonBParkTable)
 muonTriggerMatchedTables = cms.Sequence(muonTriggerMatchedTable)
-

--- a/BParkingNano/python/tracksBPark_cff.py
+++ b/BParkingNano/python/tracksBPark_cff.py
@@ -3,42 +3,32 @@ from PhysicsTools.NanoAOD.common_cff import *
 
 tracksBPark = cms.EDProducer('TrackMerger',
                              beamSpot   = cms.InputTag("offlineBeamSpot"),
-                             trgMuon    = cms.InputTag("muonTrgSelector:trgMatched"),
+                             trgMuon    = cms.InputTag("muonTrgSelector:trgMuons"),
                              tracks     = cms.InputTag("packedPFCandidates"),
                              lostTracks = cms.InputTag("lostTracks"),
                              trkPtCut = cms.double(0.5),    
-                             trkEtaCut = cms.double(2.4),
-                             dzTrg_cleaning = cms.double(1.),
-                             ## the following 2 to -1 switch off the 
-                             ## difference between Probe and Tag side
-                             ## only Probe side if filled wo selection on dR nor dca
-                             drTrg_ProbeCleaning = cms.double(0.4),
-                             drTrg_TagCleaning = cms.double(0.8),
-                             dcaSig_probe = cms.double(1.5),
-                             dcaSig_tag = cms.double(0.5),
+                             trkEtaCut = cms.double(2.5),
+                             dzTrg_cleaning = cms.double(-1.),
+                             drTrg_Cleaning = cms.double(-0.4),
+                             dcaSig = cms.double(-100000),
                              trkNormChiMin = cms.int32(-1),
-                             trkNormChiMax = cms.int32(100)
+                             trkNormChiMax = cms.int32(-1)
                             )
 
 
 trackBParkTable = cms.EDProducer(
     "SimpleCompositeCandidateFlatTableProducer",
-    src = cms.InputTag("tracksBPark:ProbeSide"),
-    cut = cms.string(""), #we should not filter on cross linked collections
+    src = cms.InputTag("tracksBPark:SelectedTracks"),
+    cut = cms.string(""),
     name = cms.string("ProbeTracks"),
     doc  = cms.string("track collection probe side for BPark after basic selection"),
-    singleton = cms.bool(False), # the number of entries is variable
-    extension = cms.bool(False), # this is the main table for the muons
+    singleton = cms.bool(False),
+    extension = cms.bool(False), 
     variables = cms.PSet(
-        pt = Var("daughter(0).pt()",float,doc="pt", precision=10),
-        eta = Var("daughter(0).eta()",float,doc="eta", precision=10),
-        phi = Var("daughter(0).phi()",float,doc="phi", precision=10),
-        charge = Var("daughter(0).charge()",float,doc="charge", precision=10),
-        mass = Var("daughter(0).mass()",float,doc="mass", precision=10),
-        pdgId = Var("daughter(0).pdgId()",int,doc="PF pdgID", precision=10),
-        vx = Var("daughter(0).vx()", float, doc="x coordinate of vertex position, in cm", precision=10),
-        vy = Var("daughter(0).vy()", float, doc="y coordinate of vertex position, in cm", precision=10),
-        vz = Var("daughter(0).vz()", float, doc="z coordinate of vertex position, in cm", precision=10),
+         CandVars,
+        #vx = Var("daughter(0).vx()", float, doc="x coordinate of vertex position, in cm", precision=10),
+        #vy = Var("daughter(0).vy()", float, doc="y coordinate of vertex position, in cm", precision=10),
+        #vz = Var("daughter(0).vz()", float, doc="z coordinate of vertex position, in cm", precision=10),
         isPacked = Var("userInt('isPacked')",int,doc="track from packedCandidate collection", precision=10),
         isLostTrk = Var("userInt('isLostTrk')",int,doc="track from lostTrack collection", precision=10),
         dz = Var("userFloat('dz')",float,doc="dz (with sign) wrt first PV, in cm", precision=10),
@@ -52,11 +42,4 @@ trackBParkTable = cms.EDProducer(
 )
 
 
-trackTagSideBParkTable = trackBParkTable.clone(
-    src = cms.InputTag("tracksBPark:TagSide"),
-    name = cms.string("TagTracks"),
-    doc  = cms.string("track collection tag side for BPark after basic selection"),
-)
 
-tracksBParkSequence = cms.Sequence(tracksBPark)
-tracksBParkTables = cms.Sequence(trackBParkTable + trackTagSideBParkTable)

--- a/BParkingNano/python/tracksBPark_cff.py
+++ b/BParkingNano/python/tracksBPark_cff.py
@@ -42,4 +42,8 @@ trackBParkTable = cms.EDProducer(
 )
 
 
+tracksBParkSequence = cms.Sequence(tracksBPark)
+tracksBParkTables = cms.Sequence(trackBParkTable)
+
+
 


### PR DESCRIPTION
Hi all,

This is a rebased version of #15
Perhaps @amartelli  wants to look at this and please give a review / comment. Essentially instead of making a huge PR i broke it in two. Here is the first part - inputs
To summarize:
   - I rewrote the the cleaning with respect to triggering muon(s) for all inputs (muons, tracks, electrons) -> cleaner and faster
   - Made the electron merger to also cut and put BDT values so we need to loop only once instead of multiple times
   - All input objects that pass the cuts are labelled: Selected<NameOfObject>
   - Removed the two selections from track merger. If we are sure that K in tag objects are within certain DR from trg muon we can uncomment it
   - Fixed the addAsDaughter in composite candidate. Now the composite candidate has correct pT, eta, phi without "hackering it" as daughter. The candidate itself is added as additional Cand. I need to check that this works in later steps though.
    - Checked on 1k evts that results are fine
    - Measured time and size wrt to the flat ntuple
   - Fixed all the relevant cffs
   - Added comments questions in line so anyone can follow
If there are comments let me know

Best,
George