### PR TITLE
Include B to kll

### DIFF
--- a/BParkingNano/plugins/BToKLLBuilder.cc
+++ b/BParkingNano/plugins/BToKLLBuilder.cc
@@ -119,7 +119,7 @@ void BToKLLBuilder::produce(edm::StreamID, edm::Event &evt, edm::EventSetup cons
     
       KinVtxFitter fitter(
         {leptons_ttracks->at(l1_idx), leptons_ttracks->at(l2_idx), kaons_ttracks->at(k_idx)},
-        {l1_ptr->mass(), l1_ptr->mass(), K_MASS},
+        {l1_ptr->mass(), l2_ptr->mass(), K_MASS},
         {LEP_SIGMA, LEP_SIGMA, K_SIGMA} //some small sigma for the lepton mass
         );
       if(!fitter.success()) continue; // hardcoded, but do we need otherwise?
@@ -134,16 +134,19 @@ void BToKLLBuilder::produce(edm::StreamID, edm::Event &evt, edm::EventSetup cons
       cand.addUserFloat("sv_chi2", fitter.chi2());
       cand.addUserFloat("sv_ndof", fitter.dof()); // float??
       cand.addUserFloat("sv_prob", fitter.prob());
-      cand.addUserFloat("fitted_mass", fitter.fitted_candidate().mass());      
       cand.addUserFloat("fitted_mll" , (fitter.daughter_p4(0) + fitter.daughter_p4(1)).mass());
-      // Failing, need to figur out a way to get them 
-      // CHECK: is this right?
-      cand.addUserFloat("fitted_pt" , fitter.fitted_candidate().globalMomentum().perp()); 
-      cand.addUserFloat("fitted_eta", fitter.fitted_candidate().globalMomentum().eta() );
-      cand.addUserFloat("fitted_phi", fitter.fitted_candidate().globalMomentum().phi() );
+      auto fit_p4 = fitter.fitted_p4();
+      cand.addUserFloat("fitted_pt"  , fit_p4.pt()); 
+      cand.addUserFloat("fitted_eta" , fit_p4.eta());
+      cand.addUserFloat("fitted_phi" , fit_p4.phi());
+      cand.addUserFloat("fitted_mass", fit_p4.mass());      
       cand.addUserFloat(
         "cos_theta_2D", 
         cos_theta_2D(fitter, *beamspot, cand.p4())
+        );
+      cand.addUserFloat(
+        "fitted_cos_theta_2D", 
+        cos_theta_2D(fitter, *beamspot, fit_p4)
         );
       auto lxy = l_xy(fitter, *beamspot);
       cand.addUserFloat("l_xy", lxy.value());

--- a/BParkingNano/plugins/BToKLLBuilder.cc
+++ b/BParkingNano/plugins/BToKLLBuilder.cc
@@ -1,0 +1,159 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
+#include <vector>
+#include <memory>
+#include <map>
+#include <string>
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "helper.h"
+#include <limits>
+#include <algorithm>
+#include "KinVtxFitter.h"
+
+class BToKLLBuilder : public edm::global::EDProducer<> {
+
+  // perhaps we need better structure here (begin run etc)
+public:
+  typedef std::vector<reco::TransientTrack> TransientTrackCollection;
+
+  explicit BToKLLBuilder(const edm::ParameterSet &cfg):
+    k_selection_{cfg.getParameter<std::string>("kaonSelection")},
+    pre_vtx_selection_{cfg.getParameter<std::string>("preVtxSelection")},
+    post_vtx_selection_{cfg.getParameter<std::string>("postVtxSelection")},
+    dileptons_{consumes<pat::CompositeCandidateCollection>( cfg.getParameter<edm::InputTag>("dileptons") )},
+    leptons_ttracks_{consumes<TransientTrackCollection>( cfg.getParameter<edm::InputTag>("leptonTransientTracks") )},
+    kaons_{consumes<pat::PackedCandidateCollection>( cfg.getParameter<edm::InputTag>("kaons") )},
+    kaons_ttracks_{consumes<TransientTrackCollection>( cfg.getParameter<edm::InputTag>("kaonsTransientTracks") )},
+    beamspot_{consumes<reco::BeamSpot>( cfg.getParameter<edm::InputTag>("beamSpot") )} {
+      produces<pat::CompositeCandidateCollection>();
+    }
+
+  ~BToKLLBuilder() override {}
+  
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {}
+  
+private:
+  const StringCutObjectSelector<pat::PackedCandidate> k_selection_; // cut on sub-leading lepton
+  const StringCutObjectSelector<pat::CompositeCandidate> pre_vtx_selection_; // cut on the di-lepton before the SV fit
+  const StringCutObjectSelector<pat::CompositeCandidate> post_vtx_selection_; // cut on the di-lepton after the SV fit
+
+  const edm::EDGetTokenT<pat::CompositeCandidateCollection> dileptons_;
+  const edm::EDGetTokenT<TransientTrackCollection> leptons_ttracks_;
+  const edm::EDGetTokenT<pat::PackedCandidateCollection> kaons_;
+  const edm::EDGetTokenT<TransientTrackCollection> kaons_ttracks_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamspot_;  
+};
+
+void BToKLLBuilder::produce(edm::StreamID, edm::Event &evt, edm::EventSetup const &) const {
+
+  //input
+  edm::Handle<pat::CompositeCandidateCollection> dileptons;
+  evt.getByToken(dileptons_, dileptons);
+  
+  edm::Handle<TransientTrackCollection> leptons_ttracks;
+  evt.getByToken(leptons_ttracks_, leptons_ttracks);
+
+  edm::Handle<pat::PackedCandidateCollection> kaons;
+  evt.getByToken(kaons_, kaons);
+  
+  edm::Handle<TransientTrackCollection> kaons_ttracks;
+  evt.getByToken(kaons_ttracks_, kaons_ttracks);  
+
+  edm::Handle<reco::BeamSpot> beamspot;
+  evt.getByToken(beamspot_, beamspot);  
+
+  // output
+  std::unique_ptr<pat::CompositeCandidateCollection> ret_val(new pat::CompositeCandidateCollection());
+  
+  for(size_t k_idx = 0; k_idx < kaons->size(); ++k_idx) {
+    edm::Ptr<pat::PackedCandidate> k_ptr(kaons, k_idx);
+    if( !k_selection_(*k_ptr) ) continue;
+    
+    math::PtEtaPhiMLorentzVector k_p4(
+      k_ptr->pt(), 
+      k_ptr->eta(),
+      k_ptr->phi(),
+      K_MASS
+      );
+
+    for(size_t ll_idx = 0; ll_idx < dileptons->size(); ++ll_idx) {
+      edm::Ptr<pat::CompositeCandidate> ll_prt(dileptons, ll_idx);
+      edm::Ptr<reco::Candidate> l1_ptr = ll_prt->userCand("l1");
+      edm::Ptr<reco::Candidate> l2_ptr = ll_prt->userCand("l2");
+      int l1_idx = ll_prt->userInt("l1_idx");
+      int l2_idx = ll_prt->userInt("l2_idx");
+    
+      pat::CompositeCandidate cand;
+      cand.setP4(ll_prt->p4() + k_p4);
+      cand.setCharge(ll_prt->charge() + k_ptr->charge());
+      // Use UserCands as they should not use memory but keep the Ptr itself
+      // Put the lepton passing the corresponding selection
+      cand.addUserCand("l1", l1_ptr);
+      cand.addUserCand("l2", l2_ptr);
+      cand.addUserCand("K", k_ptr);
+      cand.addUserCand("dilepton", ll_prt);
+
+      cand.addUserInt("l1_idx", l1_idx);
+      cand.addUserInt("l2_idx", l2_idx);
+      cand.addUserInt("k_idx", k_idx);
+    
+      auto dr_info = min_max_dr({l1_ptr, l2_ptr, k_ptr});
+      cand.addUserFloat("min_dr", dr_info.first);
+      cand.addUserFloat("max_dr", dr_info.second);
+      // TODO add meaningful variables
+    
+      if( !pre_vtx_selection_(cand) ) continue;
+    
+      KinVtxFitter fitter(
+        {leptons_ttracks->at(l1_idx), leptons_ttracks->at(l2_idx), kaons_ttracks->at(k_idx)},
+        {l1_ptr->mass(), l1_ptr->mass(), K_MASS},
+        {LEP_SIGMA, LEP_SIGMA, K_SIGMA} //some small sigma for the lepton mass
+        );
+      cand.setVertex( 
+        reco::Candidate::Point( 
+          fitter.fitted_vtx().x(),
+          fitter.fitted_vtx().y(),
+          fitter.fitted_vtx().z()
+          )  
+        );
+      cand.addUserInt("sv_OK" , fitter.success());
+      cand.addUserFloat("sv_chi2", fitter.chi2());
+      cand.addUserFloat("sv_ndof", fitter.dof()); // float??
+      cand.addUserFloat("sv_prob", fitter.prob());
+      cand.addUserFloat("fitted_mass", fitter.fitted_candidate().mass());      
+      cand.addUserFloat("fitted_mll", (fitter.daughter_p4(0) + fitter.daughter_p4(1)).mass());
+      // Failing, need to figur out a way to get them
+      cand.addUserFloat("fitted_pt" , fitter.fitted_candidate().globalMomentum().perp()); // CHECK: is this right?
+      cand.addUserFloat("fitted_eta", fitter.fitted_candidate().globalMomentum().eta());
+      cand.addUserFloat("fitted_phi", fitter.fitted_candidate().globalMomentum().phi());
+      cand.addUserFloat(
+        "cos_theta_2D", 
+        cos_theta_2D(fitter, *beamspot, cand.p4())
+        );
+      auto lxy = l_xy(fitter, *beamspot);
+      cand.addUserFloat("l_xy", lxy.value());
+      cand.addUserFloat("l_xy_unc", lxy.error());
+    
+      if( !post_vtx_selection_(cand) ) continue;        
+      ret_val->push_back(cand);
+    } // for(size_t ll_idx = 0; ll_idx < dileptons->size(); ++ll_idx) {
+  } // for(size_t k_idx = 0; k_idx < kaons->size(); ++k_idx)
+
+  evt.put(std::move(ret_val));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(BToKLLBuilder);

--- a/BParkingNano/plugins/BuildFile.xml
+++ b/BParkingNano/plugins/BuildFile.xml
@@ -22,6 +22,7 @@
 <use   name="MagneticField/Records"/>
 <use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/GsfTracking"/>
+<!--flags CXXFLAGS="-g"/-->  
 <library   file="*.cc" name="PhysicsToolsBParkingNanoPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/BParkingNano/plugins/DiLeptonBuilder.cc
+++ b/BParkingNano/plugins/DiLeptonBuilder.cc
@@ -90,7 +90,7 @@ void DiLeptonBuilder<Lepton>::produce(edm::StreamID, edm::Event &evt, edm::Event
       // Use UserCands as they should not use memory but keep the Ptr itself
       // Put the lepton passing the corresponding selection
       lepton_pair.addUserCand("l1", l1_as_l1 ? l1_ptr : l2_ptr);
-      lepton_pair.addUserCand("l2", l1_as_l2 ? l1_ptr : l2_ptr);
+      lepton_pair.addUserCand("l2", l1_as_l1 ? l2_ptr : l1_ptr);
 
       if( !pre_vtx_selection_(lepton_pair) ) continue; // before making the SV, cut on the info we have
 

--- a/BParkingNano/plugins/DiLeptonBuilder.cc
+++ b/BParkingNano/plugins/DiLeptonBuilder.cc
@@ -1,0 +1,124 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <vector>
+#include <memory>
+#include <map>
+#include <string>
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "helper.h"
+#include <limits>
+#include <algorithm>
+#include "KinVtxFitter.h"
+
+template<typename Lepton>
+class DiLeptonBuilder : public edm::global::EDProducer<> {
+
+  // perhaps we need better structure here (begin run etc)
+public:
+  typedef std::vector<Lepton> LeptonCollection;
+  typedef std::vector<reco::TransientTrack> TransientTrackCollection;
+
+  explicit DiLeptonBuilder(const edm::ParameterSet &cfg):
+    l1_selection_{cfg.getParameter<std::string>("lep1Selection")},
+    l2_selection_{cfg.getParameter<std::string>("lep2Selection")},
+    pre_vtx_selection_{cfg.getParameter<std::string>("preVtxSelection")},
+    post_vtx_selection_{cfg.getParameter<std::string>("postVtxSelection")},
+    src_{consumes<LeptonCollection>( cfg.getParameter<edm::InputTag>("src") )},
+    ttracks_src_{consumes<TransientTrackCollection>( cfg.getParameter<edm::InputTag>("transientTracksSrc") )} {
+       produces<pat::CompositeCandidateCollection>();
+    }
+
+  ~DiLeptonBuilder() override {}
+  
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {}
+  
+private:
+  const StringCutObjectSelector<Lepton> l1_selection_; // cut on leading lepton
+  const StringCutObjectSelector<Lepton> l2_selection_; // cut on sub-leading lepton
+  const StringCutObjectSelector<pat::CompositeCandidate> pre_vtx_selection_; // cut on the di-lepton before the SV fit
+  const StringCutObjectSelector<pat::CompositeCandidate> post_vtx_selection_; // cut on the di-lepton after the SV fit
+  const edm::EDGetTokenT<LeptonCollection> src_;
+  const edm::EDGetTokenT<TransientTrackCollection> ttracks_src_;
+};
+
+template<typename Lepton>
+void DiLeptonBuilder<Lepton>::produce(edm::StreamID, edm::Event &evt, edm::EventSetup const &) const {
+
+  //input
+  edm::Handle<LeptonCollection> leptons;
+  evt.getByToken(src_, leptons);
+  
+  edm::Handle<TransientTrackCollection> ttracks;
+  evt.getByToken(ttracks_src_, ttracks);
+
+  // output
+  std::unique_ptr<pat::CompositeCandidateCollection> ret_value(new pat::CompositeCandidateCollection());
+  
+  for(size_t l1_idx = 0; l1_idx < leptons->size(); ++l1_idx) {
+    edm::Ptr<Lepton> l1_ptr(leptons, l1_idx);
+    bool l1_as_l1 = l1_selection_(*l1_ptr);
+    bool l1_as_l2 = l2_selection_(*l1_ptr);
+    if( !(l1_as_l1 || l1_as_l2) ) continue; 
+    
+    for(size_t l2_idx = l1_idx + 1; l2_idx < leptons->size(); ++l2_idx) {
+      edm::Ptr<Lepton> l2_ptr(leptons, l2_idx);
+      bool l2_as_l1 = l1_selection_(*l2_ptr);
+      bool l2_as_l2 = l2_selection_(*l2_ptr);
+      if( !(l2_as_l1 || l2_as_l2) ) continue;
+
+      bool l1_l2 = l1_as_l1 && l2_as_l2;
+      bool l2_l1 = l2_as_l1 && l1_as_l2;
+      if( !(l1_l2 || l2_l1) ) continue; // make sure both leptons pass opposite selections
+
+      pat::CompositeCandidate lepton_pair;
+      lepton_pair.setP4(l1_ptr->p4() + l2_ptr->p4());
+      lepton_pair.setCharge(l1_ptr->charge() + l2_ptr->charge());
+      lepton_pair.addUserFloat("lep_deltaR", reco::deltaR(*l1_ptr, *l2_ptr));
+      lepton_pair.addUserInt("l1_idx", l1_idx);
+      lepton_pair.addUserInt("l2_idx", l2_idx);
+      // Use UserCands as they should not use memory but keep the Ptr itself
+      // Put the lepton passing the corresponding selection
+      lepton_pair.addUserCand("l1", l1_as_l1 ? l1_ptr : l2_ptr);
+      lepton_pair.addUserCand("l2", l1_as_l2 ? l1_ptr : l2_ptr);
+
+      if( !pre_vtx_selection_(lepton_pair) ) continue; // before making the SV, cut on the info we have
+
+      KinVtxFitter fitter(
+        {ttracks->at(l1_idx), ttracks->at(l2_idx)},
+        {l1_ptr->mass(), l2_ptr->mass()},
+        {LEP_SIGMA, LEP_SIGMA} //some small sigma for the particle mass
+        );
+      lepton_pair.addUserFloat("sv_chi2", fitter.chi2());
+      lepton_pair.addUserFloat("sv_ndof", fitter.dof()); // float??
+      lepton_pair.addUserFloat("sv_prob", fitter.prob());
+      lepton_pair.addUserFloat("fitted_mass", fitter.fitted_candidate().mass());
+      // if needed, add here more stuff
+
+      // cut on the SV info
+      if( !post_vtx_selection_(lepton_pair) ) continue;
+      ret_value->push_back(lepton_pair);
+    }
+  }
+  
+  evt.put(std::move(ret_value));
+}
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+typedef DiLeptonBuilder<pat::Muon> DiMuonBuilder;
+typedef DiLeptonBuilder<pat::Electron> DiElectronBuilder;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(DiMuonBuilder);
+DEFINE_FWK_MODULE(DiElectronBuilder);

--- a/BParkingNano/plugins/DiLeptonBuilder.cc
+++ b/BParkingNano/plugins/DiLeptonBuilder.cc
@@ -102,7 +102,7 @@ void DiLeptonBuilder<Lepton>::produce(edm::StreamID, edm::Event &evt, edm::Event
       lepton_pair.addUserFloat("sv_chi2", fitter.chi2());
       lepton_pair.addUserFloat("sv_ndof", fitter.dof()); // float??
       lepton_pair.addUserFloat("sv_prob", fitter.prob());
-      lepton_pair.addUserFloat("fitted_mass", fitter.fitted_candidate().mass());
+      lepton_pair.addUserFloat("fitted_mass", fitter.success() ? fitter.fitted_candidate().mass() : -1);
       // if needed, add here more stuff
 
       // cut on the SV info

--- a/BParkingNano/plugins/KinVtxFitter.cc
+++ b/BParkingNano/plugins/KinVtxFitter.cc
@@ -1,0 +1,45 @@
+#include "KinVtxFitter.h"
+#include "RecoVertex/KinematicFitPrimitives/interface/KinematicParticleFactoryFromTransientTrack.h"
+#include "RecoVertex/KinematicFit/interface/KinematicConstrainedVertexFitter.h"
+#include "RecoVertex/KinematicFit/interface/TwoTrackMassKinematicConstraint.h" // MIGHT be useful for Phi->KK?
+
+KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks, 
+                           const std::vector<double> masses, 
+                           std::vector<float> sigmas):
+  n_particles_{masses.size()} {
+  
+  KinematicParticleFactoryFromTransientTrack factory;
+  std::vector<RefCountedKinematicParticle> particles;
+  for(size_t i = 0; i < tracks.size(); ++i) {
+    particles.emplace_back(
+      factory.particle(
+        tracks.at(i), masses.at(i), kin_chi2_, 
+        kin_ndof_, sigmas[i]
+        )
+      );
+  }
+
+  KinematicConstrainedVertexFitter kcv_fitter;    
+  RefCountedKinematicTree vtx_tree = kcv_fitter.fit(particles);
+
+  if (vtx_tree->isEmpty() || !vtx_tree->isValid() || !vtx_tree->isConsistent()) {
+    success_ = false; 
+    return;
+  }
+
+  vtx_tree->movePointerToTheTop(); 
+  fitted_particle_ = vtx_tree->currentParticle();
+  fitted_vtx_ = vtx_tree->currentDecayVertex();
+  if (!fitted_particle_->currentState().isValid() || !fitted_vtx_->vertexIsValid()){ 
+    success_ = false; 
+    return;
+  }
+  fitted_state_ = fitted_particle_->currentState();
+  fitted_children_ = vtx_tree->finalStateParticles();
+  if(fitted_children_.size() != n_particles_) { 
+    success_=false; 
+    return;
+  }
+  fitted_track_ = fitted_particle_->refittedTransientTrack();
+  success_ = true;
+}

--- a/BParkingNano/plugins/KinVtxFitter.h
+++ b/BParkingNano/plugins/KinVtxFitter.h
@@ -49,12 +49,24 @@ public:
   const KinematicState fitted_candidate() const {
     return fitted_state_;
   }
+
+  const math::PtEtaPhiMLorentzVector fitted_p4() const { 
+    return math::PtEtaPhiMLorentzVector(
+      fitted_state_.globalMomentum().perp(), 
+      fitted_state_.globalMomentum().eta() ,
+      fitted_state_.globalMomentum().phi() ,
+      fitted_state_.mass()
+      );
+  }
+
   const reco::TransientTrack& fitted_candidate_ttrk() const {
     return fitted_track_;
   }
+
   GlobalPoint fitted_vtx() const {
     return fitted_vtx_->position();
   }
+
   GlobalError fitted_vtx_uncertainty() const {
     return fitted_vtx_->error();
   }

--- a/BParkingNano/plugins/KinVtxFitter.h
+++ b/BParkingNano/plugins/KinVtxFitter.h
@@ -1,0 +1,74 @@
+#ifndef PhysicsTools_BParkingNano_KinVtxFitter
+#define PhysicsTools_BParkingNano_KinVtxFitter
+
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "RecoVertex/KinematicFitPrimitives/interface/RefCountedKinematicVertex.h"
+#include "RecoVertex/KinematicFitPrimitives/interface/KinematicState.h"
+#include "RecoVertex/KinematicFitPrimitives/interface/RefCountedKinematicParticle.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include <vector>
+
+class KinVtxFitter {
+public: 
+  KinVtxFitter():
+    fitted_vtx_{}, 
+    fitted_state_{},
+    fitted_particle_{},
+    fitted_children_{},
+    fitted_track_{} {};
+
+  KinVtxFitter(const std::vector<reco::TransientTrack> tracks, 
+               const std::vector<double> masses, 
+               std::vector<float> sigmas);
+
+  ~KinVtxFitter() {};
+
+  bool success() const {return success_;}
+  float chi2() const {return success_ ? fitted_vtx_->chiSquared() : 999;}
+  float dof() const  {return success_ ? fitted_vtx_->degreesOfFreedom() : -1;}
+  float prob() const {
+    return success_ ? ChiSquaredProbability(chi2(), dof()) : 0.;
+  }
+  float kin_chi2() const {return kin_chi2_;} // should they be merged in a single value?
+  float kin_ndof() const {return kin_ndof_;}
+  
+  const KinematicState fitted_daughter(size_t i) const { 
+    return fitted_children_.at(i)->initialState(); // CHECK: is inital right?
+  }
+
+  const math::PtEtaPhiMLorentzVector daughter_p4(size_t i) const { 
+    const auto& state = fitted_children_.at(i)->initialState();
+    return math::PtEtaPhiMLorentzVector(
+      state.globalMomentum().perp(), // CHECK: is this right?
+      state.globalMomentum().eta() ,
+      state.globalMomentum().phi() ,
+      state.mass()
+      );
+  }
+
+  const KinematicState fitted_candidate() const {
+    return fitted_state_;
+  }
+  const reco::TransientTrack& fitted_candidate_ttrk() const {
+    return fitted_track_;
+  }
+  GlobalPoint fitted_vtx() const {
+    return fitted_vtx_->position();
+  }
+  GlobalError fitted_vtx_uncertainty() const {
+    return fitted_vtx_->error();
+  }
+
+private:
+  float kin_chi2_ = 0.;
+  float kin_ndof_ = 0.;
+  size_t n_particles_ = 0;
+  bool success_ = false;
+
+  RefCountedKinematicVertex fitted_vtx_; 
+  KinematicState fitted_state_;
+  RefCountedKinematicParticle fitted_particle_;
+  std::vector< RefCountedKinematicParticle > fitted_children_;
+  reco::TransientTrack fitted_track_;
+};
+#endif

--- a/BParkingNano/plugins/KinVtxFitter.h
+++ b/BParkingNano/plugins/KinVtxFitter.h
@@ -33,13 +33,13 @@ public:
   float kin_ndof() const {return kin_ndof_;}
   
   const KinematicState fitted_daughter(size_t i) const { 
-    return fitted_children_.at(i)->initialState(); // CHECK: is inital right?
+    return fitted_children_.at(i)->currentState(); 
   }
 
   const math::PtEtaPhiMLorentzVector daughter_p4(size_t i) const { 
-    const auto& state = fitted_children_.at(i)->initialState();
+    const auto& state = fitted_children_.at(i)->currentState();
     return math::PtEtaPhiMLorentzVector(
-      state.globalMomentum().perp(), // CHECK: is this right?
+      state.globalMomentum().perp(), 
       state.globalMomentum().eta() ,
       state.globalMomentum().phi() ,
       state.mass()

--- a/BParkingNano/plugins/helper.h
+++ b/BParkingNano/plugins/helper.h
@@ -35,8 +35,8 @@ inline std::pair<float, float> min_max_dr(const std::vector< edm::Ptr<reco::Cand
   return std::make_pair(min_dr, max_dr);
 }
 
-template<typename FITTER>
-inline double cos_theta_2D(const FITTER& fitter, const reco::BeamSpot &bs, const reco::Candidate::LorentzVector& p4) {
+template<typename FITTER, typename LORENTZ_VEC>
+inline double cos_theta_2D(const FITTER& fitter, const reco::BeamSpot &bs, const LORENTZ_VEC& p4) {
   if(!fitter.success()) return -2;
   GlobalPoint point = fitter.fitted_vtx();
   auto bs_pos = bs.position(point.z());

--- a/BParkingNano/plugins/helper.h
+++ b/BParkingNano/plugins/helper.h
@@ -57,4 +57,3 @@ inline Measurement1D l_xy(const FITTER& fitter, const reco::BeamSpot &bs) {
 }
 
 #endif
->>>>>>> expanded common helpers

--- a/BParkingNano/plugins/helper.h
+++ b/BParkingNano/plugins/helper.h
@@ -1,4 +1,20 @@
+#ifndef PhysicsTools_BParkingNano_helpers
+#define PhysicsTools_BParkingNano_helpers
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/Measurement1D.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
+#include <vector>
+#include <algorithm>
+#include <limits>
+#include <memory>
+
+typedef std::vector<reco::TransientTrack> TransientTrackCollection;
 
 constexpr float K_MASS = 0.493677;
 constexpr float PI_MASS = 0.139571;
@@ -6,4 +22,39 @@ constexpr float LEP_SIGMA = 0.0000001;
 constexpr float K_SIGMA = 0.000016;
 constexpr float PI_SIGMA = 0.000016;
 
-typedef std::vector<reco::TransientTrack> TransientTrackCollection;
+inline std::pair<float, float> min_max_dr(const std::vector< edm::Ptr<reco::Candidate> > & cands) {
+  float min_dr = std::numeric_limits<float>::max();
+  float max_dr = 0.;
+  for(size_t i = 0; i < cands.size(); ++i) {
+    for(size_t j = i+1; j < cands.size(); ++j) {
+      float dr = reco::deltaR(*cands.at(i), *cands.at(j));
+      min_dr = std::min(min_dr, dr);
+      max_dr = std::max(max_dr, dr);
+    }
+  }
+  return std::make_pair(min_dr, max_dr);
+}
+
+template<typename FITTER>
+inline double cos_theta_2D(const FITTER& fitter, const reco::BeamSpot &bs, const reco::Candidate::LorentzVector& p4) {
+  if(!fitter.success()) return -2;
+  GlobalPoint point = fitter.fitted_vtx();
+  auto bs_pos = bs.position(point.z());
+  math::XYZVector delta(point.x() - bs_pos.x(), point.y() - bs_pos.y(), 0.);
+  math::XYZVector pt(p4.px(), p4.py(), 0.);
+  double den = (delta.R() * pt.R());
+  return (den != 0.) ? delta.Dot(pt)/den : -2;
+}
+
+template<typename FITTER>
+inline Measurement1D l_xy(const FITTER& fitter, const reco::BeamSpot &bs) {
+  if(!fitter.success()) return {-2, -2};
+  GlobalPoint point = fitter.fitted_vtx();
+  GlobalError err = fitter.fitted_vtx_uncertainty();
+  auto bs_pos = bs.position(point.z());
+  GlobalPoint delta(point.x() - bs_pos.x(), point.y() - bs_pos.y(), 0.);  
+  return {delta.perp(), err.rerr(delta)};
+}
+
+#endif
+>>>>>>> expanded common helpers

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -70,21 +70,30 @@ BToKeeTable = cms.EDProducer(
     singleton=cms.bool(False),
     extension=cms.bool(False),
     variables=cms.PSet(
+        # pre-fit quantities
         CandVars,
         l1Idx = uint('l1_idx'),
         l2Idx = uint('l2_idx'),
         kIdx = uint('k_idx'),
+        minDR = ufloat('min_dr'),
+        maxDR = ufloat('max_dr'),
+        # fit and vtx info
         chi2 = ufloat('sv_chi2'),
         svprob = ufloat('sv_prob'),
+        l_xy = ufloat('l_xy'),
+        l_xy_unc = ufloat('l_xy_unc'),
+        # Mll
         mll_raw = Var('userCand("dilepton").mass()', float),
         mll_llfit = Var('userCand("dilepton").userFloat("fitted_mass")', float), # this might not work
         mll_fullfit = ufloat('fitted_mll'),
+        # Cos(theta)
         cos2D = ufloat('cos_theta_2D'),
+        fit_cos2D = ufloat('fitted_cos_theta_2D'),
+        # post-fit momentum
         fit_mass = ufloat('fitted_mass'),
-        l_xy = ufloat('l_xy'),
-        l_xy_unc = ufloat('l_xy_unc'),
-        minDR = ufloat('min_dr'),
-        maxDR = ufloat('max_dr'),
+        fit_pt = ufloat('fitted_pt'),
+        fit_eta = ufloat('fitted_eta'),
+        fit_phi = ufloat('fitted_phi'),
     )
 )
 

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -83,6 +83,8 @@ BToKeeTable = cms.EDProducer(
         fit_mass = ufloat('fitted_mass'),
         l_xy = ufloat('l_xy'),
         l_xy_unc = ufloat('l_xy_unc'),
+        minDR = ufloat('min_dr'),
+        maxDR = ufloat('max_dr'),
     )
 )
 

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -1,0 +1,100 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.BParkingNano.common_cff import *
+
+electronPairsForKee = cms.EDProducer(
+    'DiElectronBuilder',
+    src = cms.InputTag('electronsForAnalysis', 'SelectedElectrons'),
+    transientTracksSrc = cms.InputTag('electronsForAnalysis', 'FIXME'),
+    lep1Selection = cms.string('pt > 1.5 && (userInt("isPF") == 1 || electronID("unbiased_seed") >= 3 )'),
+    lep2Selection = cms.string('pt > 0.5 && (userInt("isPF") == 1 || electronID("unbiased_seed") >= -4)'),
+    preVtxSelection = cms.string(
+        'abs(userCand("l1").vz - userCand("l2").vz) <= 1. && mass() < 5 '
+        '&& mass() > 0 && charge() == 0 && userFloat("lep_deltaR") > 0.03'
+    ),
+    postVtxSelection = cms.string('userFloat("sv_chi2") < 998 && userFloat("sv_prob") > 0'),
+)
+
+BToKee = cms.EDProducer(
+    'BToKLLBuilder',
+    dileptons = cms.InputTag('electronPairsForKee'),
+    leptonTransientTracks = electronPairsForKee.transientTracksSrc,
+    kaons = cms.InputTag('tracksBPark', 'SelectedTracks'),
+    kaonsTransientTracks = cms.InputTag('tracksBPark', 'FIXME'),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    kaonSelection = cms.string(''),
+    preVtxSelection = cms.string(
+        'pt > 3. && userFloat("min_dr") > 0.01 '
+        '&& mass < 6 && mass > 4.5'
+        ),
+    postVtxSelection = cms.string(
+        'userInt("sv_OK") == 1 && userFloat("sv_prob") > 0.00000001 '
+        '&& userFloat("cos_theta_2D") >= 0'
+    )
+)
+
+muonPairsForKmumu = cms.EDProducer(
+    'DiMuonBuilder',
+    src = cms.InputTag('muonTrgSelector', 'SelectedMuons'),
+    transientTracksSrc = cms.InputTag('muonTrgSelector', 'FIXME'),
+    lep1Selection = cms.string(''), #FIXME
+    lep2Selection = cms.string(''),
+    preVtxSelection = electronPairsForKee.preVtxSelection,
+    postVtxSelection = electronPairsForKee.postVtxSelection,
+)
+
+BToKmumu = cms.EDProducer(
+    'BToKLLBuilder',
+    dileptons = cms.InputTag('muonPairsForKmumu'),
+    leptonTransientTracks = muonPairsForKmumu.transientTracksSrc,
+    kaons = cms.InputTag('tracksBPark', 'SelectedTracks'),
+    kaonsTransientTracks = cms.InputTag('tracksBPark', 'FIXME'),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    kaonSelection = cms.string(''),
+    # This in principle can be different between electrons and muons
+    preVtxSelection = cms.string(
+        'pt > 3. && userFloat("min_dr") > 0.01 '
+        '&& mass < 6 && mass > 4.5'
+        ),
+    postVtxSelection = cms.string(
+        'userInt("sv_OK") == 1 && userFloat("sv_prob") > 0.00000001 '
+        '&& userFloat("cos_theta_2D") >= 0'
+    )
+)
+
+BToKeeTable = cms.EDProducer(
+    'SimpleCompositeCandidateFlatTableProducer',
+    src = cms.InputTag("BToKee"),
+    cut = cms.string(""),
+    name = cms.string("BToKEE"),
+    doc = cms.string("BToKEE Variable"),
+    singleton=cms.bool(False),
+    extension=cms.bool(False),
+    variables=cms.PSet(
+        CandVars,
+        el1Idx = uint('l1_idx'),
+        el2Idx = uint('l2_idx'),
+        kIdx = uint('k_idx'),
+        chi2 = ufloat('sv_chi2'),
+        svprob = ufloat('sv_prob'),
+        mll_raw = Var('userCand("dilepton").mass()', float),
+        mll_llfit = Var('userCand("dilepton").userFloat("fitted_mass")', float), # this might not work
+        mll_fullfit = ufloat('fitted_mll'),
+        cos2D = ufloat('cos_theta_2D'),
+        fit_mass = ufloat('fitted_mass'),
+        l_xy = ufloat('l_xy'),
+        l_xy_unc = ufloat('l_xy_unc'),
+    )
+)
+
+BToKmumuTable = BToKeeTable.clone(
+    src = cms.InputTag("BToKmumu"),
+    name = cms.string("BToKMuMu"),
+    doc = cms.string("BToKMuMu Variable")
+)
+
+BToKLLSequence = cms.Sequence(
+    (electronPairsForKee * BToKee) +
+    (muonPairsForKmumu * BToKmumu)
+)
+BToKLLTables = cms.Sequence(BToKeeTable + BToKmumuTable)
+

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -71,8 +71,8 @@ BToKeeTable = cms.EDProducer(
     extension=cms.bool(False),
     variables=cms.PSet(
         CandVars,
-        el1Idx = uint('l1_idx'),
-        el2Idx = uint('l2_idx'),
+        l1Idx = uint('l1_idx'),
+        l2Idx = uint('l2_idx'),
         kIdx = uint('k_idx'),
         chi2 = ufloat('sv_chi2'),
         svprob = ufloat('sv_prob'),

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -27,8 +27,8 @@ BToKee = cms.EDProducer(
         '&& mass < 6 && mass > 4.5'
         ),
     postVtxSelection = cms.string(
-        'userInt("sv_OK") == 1 && userFloat("sv_prob") > 0.00000001 '
-        '&& userFloat("cos_theta_2D") >= 0'
+        'userInt("sv_OK") == 1 && userFloat("sv_prob") > 0.001 '
+        '&& userFloat("fitted_cos_theta_2D") >= 0'
     )
 )
 
@@ -36,9 +36,10 @@ muonPairsForKmumu = cms.EDProducer(
     'DiMuonBuilder',
     src = cms.InputTag('muonTrgSelector', 'SelectedMuons'),
     transientTracksSrc = cms.InputTag('muonTrgSelector', 'SelectedTransientMuons'),
-    lep1Selection = cms.string(''), #FIXME
+    lep1Selection = cms.string('pt > 1.5'),
     lep2Selection = cms.string(''),
-    preVtxSelection = electronPairsForKee.preVtxSelection,
+    preVtxSelection = cms.string('abs(userCand("l1").vz - userCand("l2").vz) <= 1. && mass() < 5 '
+                                 '&& mass() > 0 && charge() == 0'),
     postVtxSelection = electronPairsForKee.postVtxSelection,
 )
 
@@ -56,8 +57,8 @@ BToKmumu = cms.EDProducer(
         '&& mass < 6 && mass > 4.5'
         ),
     postVtxSelection = cms.string(
-        'userInt("sv_OK") == 1 && userFloat("sv_prob") > 0.00000001 '
-        '&& userFloat("cos_theta_2D") >= 0'
+        'userInt("sv_OK") == 1 && userFloat("sv_prob") > 0.001 '
+        '&& userFloat("fitted_cos_theta_2D") >= 0'
     )
 )
 

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -4,9 +4,9 @@ from PhysicsTools.BParkingNano.common_cff import *
 electronPairsForKee = cms.EDProducer(
     'DiElectronBuilder',
     src = cms.InputTag('electronsForAnalysis', 'SelectedElectrons'),
-    transientTracksSrc = cms.InputTag('electronsForAnalysis', 'FIXME'),
-    lep1Selection = cms.string('pt > 1.5 && (userInt("isPF") == 1 || electronID("unbiased_seed") >= 3 )'),
-    lep2Selection = cms.string('pt > 0.5 && (userInt("isPF") == 1 || electronID("unbiased_seed") >= -4)'),
+    transientTracksSrc = cms.InputTag('electronsForAnalysis', 'SelectedTransientElectrons'),
+    lep1Selection = cms.string('pt > 1.5 && (userInt("isPF") == 1 || userFloat("unBiased") >= 3 )'),
+    lep2Selection = cms.string('pt > 0.5 && (userInt("isPF") == 1 || userFloat("unBiased") >= -4)'),
     preVtxSelection = cms.string(
         'abs(userCand("l1").vz - userCand("l2").vz) <= 1. && mass() < 5 '
         '&& mass() > 0 && charge() == 0 && userFloat("lep_deltaR") > 0.03'
@@ -19,7 +19,7 @@ BToKee = cms.EDProducer(
     dileptons = cms.InputTag('electronPairsForKee'),
     leptonTransientTracks = electronPairsForKee.transientTracksSrc,
     kaons = cms.InputTag('tracksBPark', 'SelectedTracks'),
-    kaonsTransientTracks = cms.InputTag('tracksBPark', 'FIXME'),
+    kaonsTransientTracks = cms.InputTag('tracksBPark', 'SelectedTransientTracks'),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     kaonSelection = cms.string(''),
     preVtxSelection = cms.string(
@@ -35,7 +35,7 @@ BToKee = cms.EDProducer(
 muonPairsForKmumu = cms.EDProducer(
     'DiMuonBuilder',
     src = cms.InputTag('muonTrgSelector', 'SelectedMuons'),
-    transientTracksSrc = cms.InputTag('muonTrgSelector', 'FIXME'),
+    transientTracksSrc = cms.InputTag('muonTrgSelector', 'SelectedTransientMuons'),
     lep1Selection = cms.string(''), #FIXME
     lep2Selection = cms.string(''),
     preVtxSelection = electronPairsForKee.preVtxSelection,
@@ -46,8 +46,8 @@ BToKmumu = cms.EDProducer(
     'BToKLLBuilder',
     dileptons = cms.InputTag('muonPairsForKmumu'),
     leptonTransientTracks = muonPairsForKmumu.transientTracksSrc,
-    kaons = cms.InputTag('tracksBPark', 'SelectedTracks'),
-    kaonsTransientTracks = cms.InputTag('tracksBPark', 'FIXME'),
+    kaons = BToKee.kaons,
+    kaonsTransientTracks = BToKee.kaonsTransientTracks,
     beamSpot = cms.InputTag("offlineBeamSpot"),
     kaonSelection = cms.string(''),
     # This in principle can be different between electrons and muons

--- a/BParkingNano/python/common_cff.py
+++ b/BParkingNano/python/common_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.common_cff import *
+
+def ufloat(expr, precision = -1, doc = ''):
+  return Var('userFloat("%s")' % expr, 
+             float, precision = precision, doc = doc)
+
+def uint(expr, doc = ''):
+  return Var('userInt("%s")' % expr, int, doc = doc)
+
+def ubool(expr, precision = -1, doc = ''):
+  return Var('userInt("%s") == 1' % expr, bool, doc = doc)

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -16,7 +16,8 @@ from PhysicsTools.BParkingNano.muonsBPark_cff import *
 from PhysicsTools.BParkingNano.electronsBPark_cff import * 
 from PhysicsTools.BParkingNano.tracksBPark_cff import *
 
-
+## B collections
+from PhysicsTools.BParkingNano.BToKLL_cff import *
 
 
 nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectBParkTables + l1bits)
@@ -24,8 +25,9 @@ nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectBParkTables + l1bits)
 nanoSequence = cms.Sequence(nanoMetadata + 
                             vertexSequence +           
                             muonBParkSequence +
+                            BToKLLSequence +
                             globalTables + vertexTables + 
-                            triggerObjectBParkTables + l1bits)
+                            triggerObjectBParkTables + l1bits + BToKLLTables)
 
 nanoSequenceMC = cms.Sequence(particleLevelBParkSequence + genParticleBParkSequence + 
                               muonBParkMC + electronBParkMC +

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -25,9 +25,8 @@ nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectBParkTables + l1bits)
 nanoSequence = cms.Sequence(nanoMetadata + 
                             vertexSequence +           
                             muonBParkSequence +
-                            BToKLLSequence +
                             globalTables + vertexTables + 
-                            triggerObjectBParkTables + l1bits + BToKLLTables)
+                            triggerObjectBParkTables + l1bits)
 
 nanoSequenceMC = cms.Sequence(particleLevelBParkSequence + genParticleBParkSequence + 
                               muonBParkMC + electronBParkMC +
@@ -49,5 +48,9 @@ def nanoAOD_customizeElectronFilteredBPark(process):
 
 def nanoAOD_customizeTrackFilteredBPark(process):
     process.nanoSequence = cms.Sequence( process.nanoSequence + tracksBParkSequence + tracksBParkTables)
+    return process
+
+def nanoAOD_customizeBToKLL(process):
+    process.nanoSequence = cms.Sequence( process.nanoSequence + BToKLLSequence + BToKLLTables)
     return process
 

--- a/BParkingNano/test/run_nano_cfg.py
+++ b/BParkingNano/test/run_nano_cfg.py
@@ -124,6 +124,7 @@ from PhysicsTools.BParkingNano.nanoBPark_cff import *
 process = nanoAOD_customizeMuonTriggerBPark(process)
 process = nanoAOD_customizeElectronFilteredBPark(process)
 process = nanoAOD_customizeTrackFilteredBPark(process)
+process = nanoAOD_customizeBToKLL(process)
 
 # customisation of the process.
 if options.isMC:

--- a/BParkingNano/test/time_analysis.py
+++ b/BParkingNano/test/time_analysis.py
@@ -29,6 +29,7 @@ tot_time = sum(i for _, i in module_times)
 from collections import defaultdict
 groups = defaultdict(float)
 
+# This part is ugly, but I have no better idea
 for name, time in module_times:
   if 'gen' in name.lower():
     groups['GEN'] += time
@@ -36,6 +37,10 @@ for name, time in module_times:
     groups['GEN'] += time
   elif 'Table' in name:
     groups['Tables (not GEN)'] += time
+  elif 'kee' in name.lower():
+    groups['BToKee'] += time
+  elif 'kmumu' in name.lower():
+    groups['BToKmumu'] += time
   elif 'electron' in name.lower():
     groups['Electrons'] += time
   elif 'track' in name.lower():

--- a/BParkingNano/test/validate_pr.sh
+++ b/BParkingNano/test/validate_pr.sh
@@ -22,9 +22,9 @@ echo "...Done!"
 cd $CMSSW_BASE/src/PhysicsTools/BParkingNano/test
 TAG=HEAD
 echo "Getting reference for data..."
-cmsRun run_nano_cfg.py reportEvery=10 tag=$TAG &> nano_$TAG'_data.log'
+cmsRun run_nano_cfg.py maxEvents=1000 reportEvery=10 tag=$TAG &> nano_$TAG'_data.log'
 echo "Done! Now for MC..."
-cmsRun run_nano_cfg.py reportEvery=10 tag=$TAG isMC=True &> nano_$TAG'_mc.log'
+cmsRun run_nano_cfg.py maxEvents=1000 reportEvery=10 tag=$TAG isMC=True &> nano_$TAG'_mc.log'
 
 echo "Now merging the changes for PR #"$PRID
 git fetch $remote pull/$PRID/head:TEMP_PR$PRID
@@ -37,9 +37,9 @@ echo "...Done!"
 cd $CMSSW_BASE/src/PhysicsTools/BParkingNano/test
 TAG=PR$PRID
 echo "Testing on data..."
-cmsRun run_nano_cfg.py reportEvery=10 tag=$TAG &> nano_$TAG'_data.log'
+cmsRun run_nano_cfg.py maxEvents=1000 reportEvery=10 tag=$TAG &> nano_$TAG'_data.log'
 echo "... Done! And now on MC..."
-cmsRun run_nano_cfg.py reportEvery=10 tag=$TAG isMC=True &> nano_$TAG'_mc.log'
+cmsRun run_nano_cfg.py maxEvents=1000 reportEvery=10 tag=$TAG isMC=True &> nano_$TAG'_mc.log'
 echo "...Done! Making validation plots"
 
 rm -rf validation


### PR DESCRIPTION
This PR includes B --> K µµ and B --> K ee final states in the ntuples. The selections are copied from the old George's code, can be changed of course. 
Most of the timing is now obviously spent on making B --> K ee candidates. 
I tried replacing the `StringCutObjectSelector` most used, i.e. the pre-vertex selection of BToKee, with a hardcoded selection, the timing difference is less than 1% (0.208661 --> 0.206453), therefore I would keep it as it is. 

EDIT: All the new branches are kept with full precision at the moment, we might want to trim it down in the future, even though the lion's share of the space is currently kept by tracks.