### PR TITLE
selectedMuons as tag plus all compatible probes with flags for tags

### DIFF
--- a/BParkingNano/plugins/MuonTriggerSelector.cc
+++ b/BParkingNano/plugins/MuonTriggerSelector.cc
@@ -12,12 +12,11 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
-#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
-#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
@@ -34,8 +33,6 @@
 
 using namespace std;
 
-
-constexpr float MuonMass_ = 0.10565837;
 constexpr bool debug = false;
 
 class MuonTriggerSelector : public edm::EDProducer {
@@ -62,7 +59,7 @@ private:
 
     //for filter wrt trigger
     const double dzTrg_cleaning_; // selects primary vertex
-    const double drTrg_cleaning_; //to be used only when we want to remove tag
+
     const double ptMin_;          // min pT in all muons for B candidates
     const double absEtaMax_;      //max eta ""
     const bool softMuonsOnly_;    //cuts muons without soft ID
@@ -77,12 +74,11 @@ MuonTriggerSelector::MuonTriggerSelector(const edm::ParameterSet &iConfig):
   vertexSrc_( consumes<reco::VertexCollection> ( iConfig.getParameter<edm::InputTag>( "vertexCollection" ) ) ), 
   maxdR_(iConfig.getParameter<double>("maxdR_matching")),
   dzTrg_cleaning_(iConfig.getParameter<double>("dzForCleaning_wrtTrgMuon")),
-  drTrg_cleaning_(iConfig.getParameter<double>("drForCleaning_wrtTrgMuon")),
   ptMin_(iConfig.getParameter<double>("ptMin")),
   absEtaMax_(iConfig.getParameter<double>("absEtaMax")),
   softMuonsOnly_(iConfig.getParameter<bool>("softMuonsOnly"))
 {
-  // produce 2 collections: trgMuons (tags) and SelectedMuons (probes & tags)
+  // produce 2 collections: trgMuons (tags) and SelectedMuons (probes & tags if survive preselection cuts)
     produces<pat::MuonCollection>("trgMuons"); 
     produces<pat::MuonCollection>("SelectedMuons");
     produces<TransientTrackCollection>("SelectedTransientMuons");  
@@ -92,7 +88,6 @@ MuonTriggerSelector::MuonTriggerSelector(const edm::ParameterSet &iConfig):
 
 void MuonTriggerSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     
-
     edm::ESHandle<MagneticField> bFieldHandle;
     iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
 
@@ -161,6 +156,8 @@ void MuonTriggerSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     edm::Handle<std::vector<pat::Muon>> muons;
     iEvent.getByToken(muonSrc_, muons);
 
+    std::vector<int> isTriggerMuon(muons->size(), 0);
+
     for(const pat::Muon & muon : *muons){
       //this is for triggering muon not really need to be configurable
       unsigned int iMuo(&muon - &(muons->at(0)) );
@@ -184,43 +181,51 @@ void MuonTriggerSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       }
 
       //save reco muon 
-      //since we do not store full muon collection => useless to save original muon index
       if(recoMuonMatching_index != -1){
 	pat::Muon recoTriggerMuonCand (muon);
 	recoTriggerMuonCand.addUserInt("trgMuonIndex", trgMuonMatching_index);
 	trgmuons_out->emplace_back(recoTriggerMuonCand);
+
+	//keep track of original muon index for SelectedMuons collection
+	isTriggerMuon[iMuo] = 1;
       }
     }
-    
 
-    
-    // code simplified loop of trg inside
-      for(const pat::Muon &mu : *muons) {
-	//election cuts
-       if (mu.pt() < ptMin_) continue;
-       if (fabs(mu.eta()) > absEtaMax_) continue;
-       if (softMuonsOnly_ && !mu.isSoftMuon(PV)) continue;
 
-       // same PV as the tag muon
-       bool SkipMuon=true;
-       for (const pat::Muon & trgmu : *trgmuons_out) {
-         if( reco::deltaR(mu,trgmu) < drTrg_cleaning_ && drTrg_cleaning_ >0 )
-             continue;
-       	 if( fabs(mu.vz()-trgmu.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ >0 )
-             continue;
-         SkipMuon=false;
-       } 
-       // needs decission: what about events without trg muon? now we SKIP them
-       if (SkipMuon)  continue;
-       
-       // build transient track
-       const reco::TransientTrack muonTT((*(mu.bestTrack())), &(*bFieldHandle)); //sara: check, why not using inner track for muons?
-       if (!muonTT.isValid()) continue;
 
-       muons_out->emplace_back(mu);
-       trans_muons_out->emplace_back(muonTT);
+    // now produce output for analysis (code simplified loop of trg inside)
+    // trigger muon + all compatible in dz with any tag
+    int muIdx = -1;
+    for(auto mu : *muons) {
+      ++muIdx;
+
+      //selection cuts
+      if (mu.pt() < ptMin_) continue;
+      if (fabs(mu.eta()) > absEtaMax_) continue;
+      //following ID is needed for trigger muons not here
+      // anyway it is off in the configuration
+      if (softMuonsOnly_ && !mu.isSoftMuon(PV)) continue; 
+
+      // same PV as the tag muon, both tag and probe only dz selection
+      bool SkipMuon=true;
+      for (const pat::Muon & trgmu : *trgmuons_out) {
+	if( fabs(mu.vz()-trgmu.vz()) > dzTrg_cleaning_ && dzTrg_cleaning_ >0 )
+	  continue;
+	SkipMuon=false;
+      } 
+      // needs decission: what about events without trg muon? now we SKIP them
+      if (SkipMuon)  continue;
+
+
+      // build transient track
+      const reco::TransientTrack muonTT((*(mu.bestTrack())), &(*bFieldHandle)); //sara: check, why not using inner track for muons? 
+      if (!muonTT.isValid()) continue;
+
+      mu.addUserInt("isTriggering", isTriggerMuon[muIdx]);
+
+      muons_out->emplace_back(mu);
+      trans_muons_out->emplace_back(muonTT);
     }
-
 
     iEvent.put(std::move(trgmuons_out),    "trgMuons");
     iEvent.put(std::move(muons_out),       "SelectedMuons");

--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -10,14 +10,12 @@ muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
                                  objects = cms.InputTag("slimmedPatTrigger"),
                                  vertexCollection = cms.InputTag("offlineSlimmedPrimaryVertices"),
                                  
-                                 ##for the output matched collection                                                                                                     
-                                 maxdR_matching = cms.double(0.01),
+                                 ##for the output trigger matched collection
+                                 maxdR_matching = cms.double(0.01), #too tight 0.05 already better + check
                                  
-                                 ## for the output filtered collection                                                                                         
+                                 ## for the output selected collection (tag + all compatible in dZ)
                                  dzForCleaning_wrtTrgMuon = cms.double(1.),
-                                 # gives the possibility to run only on probe side - used in other objects
-                                 #deactivated now
-                                 drForCleaning_wrtTrgMuon = cms.double (-1.),
+
                                  ptMin = cms.double(1.),
                                  absEtaMax = cms.double(2.4),
                                  # keeps only muons with at soft Quality flag
@@ -66,6 +64,7 @@ muonBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         multiIsoId = Var("?passed('MultiIsoMedium')?2:passed('MultiIsoLoose')","uint8",doc="MultiIsoId from miniAOD selector (1=MultiIsoLoose, 2=MultiIsoMedium)"),
         triggerIdLoose = Var("passed('TriggerIdLoose')",bool,doc="TriggerIdLoose ID"),
         inTimeMuon = Var("passed('InTimeMuon')",bool,doc="inTimeMuon ID"),
+        isTriggering = Var("userInt('isTriggering')", int,doc="flag the reco muon is also triggering")
     ),
 )
 


### PR DESCRIPTION
Assure that the SelectedMuon collection is tagMuons + all others compatible in dZ with any tagMuon, provided they survive the preselection cuts

- flag the SelectedMuons as triggering if it's the case
- also clean the headers removing duplicated and the non pertinent, replaced with the more appropriate
- removal of dR check wrt trigger muon
- comments on parameters for match to trigger muon in the configuration, but left unchanged for the moment

As a note (to keep in mind, but very low priority): the TT are here built with the magfield constructor, as done in TrackMerger (where the mag field is needed also for DCA)
Should update the Electronmerger to have a consistent constructor? Or Should change this one (in MuonProducer) if getting the TTBuilder instead of the MagField is faster?  