### PR TITLE
Add possibility to filter on presence of trigger muons and B candidates

### DIFF
--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -104,6 +104,25 @@ BToKmumuTable = BToKeeTable.clone(
     doc = cms.string("BToKMuMu Variable")
 )
 
+
+CountBToKee = cms.EDFilter("PATCandViewCountFilter",
+    minNumber = cms.uint32(1),
+    maxNumber = cms.uint32(999999),
+    src = cms.InputTag("BToKee")
+)    
+CountBToKmumu = CountBToKee.clone(
+    minNumber = cms.uint32(1),
+    src = cms.InputTag("BToKmumu")
+)
+
+
+BToKMuMuSequence = cms.Sequence(
+    (muonPairsForKmumu * BToKmumu)
+)
+BToKEESequence = cms.Sequence(
+    (electronPairsForKee * BToKee)
+)
+
 BToKLLSequence = cms.Sequence(
     (electronPairsForKee * BToKee) +
     (muonPairsForKmumu * BToKmumu)

--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -24,6 +24,12 @@ muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
                                  softMuonsOnly = cms.bool(False)
                              )
 
+countTrgMuons = cms.EDFilter("PATCandViewCountFilter",
+    minNumber = cms.uint32(1),
+    maxNumber = cms.uint32(999999),
+    src = cms.InputTag("muonTrgSelector", "trgMuons")
+)
+
 
 muonBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("muonTrgSelector:SelectedMuons"),
@@ -106,7 +112,8 @@ muonTriggerMatchedTable = muonBParkTable.clone(
 )
 
 
-muonBParkSequence = cms.Sequence(muonTrgSelector)
+
+muonBParkSequence = cms.Sequence(muonTrgSelector * countTrgMuons)
 muonBParkMC = cms.Sequence(muonsBParkMCMatchForTable + muonBParkMCTable)
 muonBParkTables = cms.Sequence(muonBParkTable)
 muonTriggerMatchedTables = cms.Sequence(muonTriggerMatchedTable)

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -23,7 +23,6 @@ nanoSequenceOnlyFullSim = cms.Sequence(triggerObjectBParkTables + l1bits)
 
 nanoSequence = cms.Sequence(nanoMetadata + 
                             vertexSequence +           
-                            muonBParkSequence +
                             globalTables + vertexTables + 
                             triggerObjectBParkTables + l1bits)
 
@@ -41,15 +40,17 @@ def nanoAOD_customizeMuonTriggerBPark(process):
     process.nanoSequence = cms.Sequence( process.nanoSequence + muonBParkSequence + muonTriggerMatchedTables + muonBParkTables)
     return process
 
-def nanoAOD_customizeElectronFilteredBPark(process):
-    process.nanoSequence = cms.Sequence( process.nanoSequence + electronsBParkSequence + electronBParkTables)
-    return process
-
 def nanoAOD_customizeTrackFilteredBPark(process):
     process.nanoSequence = cms.Sequence( process.nanoSequence + tracksBParkSequence + tracksBParkTables)
     return process
 
-def nanoAOD_customizeBToKLL(process):
-    process.nanoSequence = cms.Sequence( process.nanoSequence + BToKLLSequence + BToKLLTables)
+def nanoAOD_customizeElectronFilteredBPark(process):
+    process.nanoBKeeSequence = cms.Sequence( electronsBParkSequence + electronBParkTables)
     return process
+
+def nanoAOD_customizeBToKLL(process):
+    process.nanoBKeeSequence   = cms.Sequence( process.nanoBKeeSequence + BToKEESequence    + BToKeeTable   + CountBToKee)
+    process.nanoBKMuMuSequence = cms.Sequence(                            BToKMuMuSequence  + BToKmumuTable + CountBToKmumu)
+    return process
+
 

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -27,7 +27,6 @@ nanoSequence = cms.Sequence(nanoMetadata +
                             triggerObjectBParkTables + l1bits)
 
 nanoSequenceMC = cms.Sequence(particleLevelBParkSequence + genParticleBParkSequence + 
-                              muonBParkMC + electronBParkMC +
                               globalTablesMC + genWeightsTable + genParticleBParkTables + particleLevelBParkTables + lheInfoTable) 
 
 
@@ -50,8 +49,14 @@ def nanoAOD_customizeBToKLL(process):
     return process
 
 def nanoAOD_customizeMC(process):
-    process.nanoSequenceMC = cms.Sequence(  nanoSequenceMC)
-#     process.nanoSequence = cms.Sequence( process.nanoSequence + nanoSequenceMC)
-    return process
-
+    for ipath in process._Process__paths.items():
+        path = process.paths[ipath[0]]
+        try:
+            index  = path.index(process.nanoBKeeSequence)
+            path.insert(index+1, electronBParkMC)
+        except:
+            pass
+        
+        path.insert(0, nanoSequenceMC)
+        path.insert(3, muonBParkMC)
 

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -32,10 +32,6 @@ nanoSequenceMC = cms.Sequence(particleLevelBParkSequence + genParticleBParkSeque
 
 
 
-def nanoAOD_customizeMC(process):
-    process.nanoSequence = cms.Sequence( process.nanoSequence + nanoSequenceMC)
-    return process
-
 def nanoAOD_customizeMuonTriggerBPark(process):
     process.nanoSequence = cms.Sequence( process.nanoSequence + muonBParkSequence + muonTriggerMatchedTables + muonBParkTables)
     return process
@@ -51,6 +47,11 @@ def nanoAOD_customizeElectronFilteredBPark(process):
 def nanoAOD_customizeBToKLL(process):
     process.nanoBKeeSequence   = cms.Sequence( process.nanoBKeeSequence + BToKEESequence    + BToKeeTable   + CountBToKee)
     process.nanoBKMuMuSequence = cms.Sequence(                            BToKMuMuSequence  + BToKmumuTable + CountBToKmumu)
+    return process
+
+def nanoAOD_customizeMC(process):
+    process.nanoSequenceMC = cms.Sequence(  nanoSequenceMC)
+#     process.nanoSequence = cms.Sequence( process.nanoSequence + nanoSequenceMC)
     return process
 
 

--- a/BParkingNano/test/run_nano_cfg.py
+++ b/BParkingNano/test/run_nano_cfg.py
@@ -106,26 +106,40 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, globaltag, '')
 
 
-# Path and EndPath definitions
-process.nanoAOD_step = cms.Path(process.nanoSequence)
-process.endjob_step = cms.EndPath(process.endOfProcess)
-process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
-process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
-
-
-# Schedule definition
-process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step, process.NANOAODoutput_step)
-if options.wantFullRECO:
-    process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step, process.FEVTDEBUGHLToutput_step, process.NANOAODoutput_step)
-from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
-associatePatAlgosToolsTask(process)
-
 from PhysicsTools.BParkingNano.nanoBPark_cff import *
 process = nanoAOD_customizeMuonTriggerBPark(process)
 process = nanoAOD_customizeElectronFilteredBPark(process)
 process = nanoAOD_customizeTrackFilteredBPark(process)
 process = nanoAOD_customizeBToKLL(process)
 
+# Path and EndPath definitions
+process.nanoAOD_KMuMu_step = cms.Path(process.nanoSequence + process.nanoBKMuMuSequence)
+process.nanoAOD_Kee_step   = cms.Path(process.nanoSequence + process.nanoBKeeSequence  )
+
+# process.nanoAOD_step = cms.Path(process.nanoSequence)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(
+                                process.nanoAOD_KMuMu_step,
+                                process.nanoAOD_Kee_step, 
+                                process.endjob_step, 
+                                process.NANOAODoutput_step
+                               )
+if options.wantFullRECO:
+    process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step, process.FEVTDEBUGHLToutput_step, process.NANOAODoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+process.NANOAODoutput.SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring(
+                                   'nanoAOD_KMuMu_step', 
+                                   'nanoAOD_Kee_step'
+                                   )
+)
+    
 # customisation of the process.
 if options.isMC:
     from PhysicsTools.BParkingNano.nanoBPark_cff import nanoAOD_customizeMC

--- a/BParkingNano/test/run_nano_cfg.py
+++ b/BParkingNano/test/run_nano_cfg.py
@@ -112,11 +112,15 @@ process = nanoAOD_customizeElectronFilteredBPark(process)
 process = nanoAOD_customizeTrackFilteredBPark(process)
 process = nanoAOD_customizeBToKLL(process)
 
-# Path and EndPath definitions
-process.nanoAOD_KMuMu_step = cms.Path(process.nanoSequence + process.nanoBKMuMuSequence)
-process.nanoAOD_Kee_step   = cms.Path(process.nanoSequence + process.nanoBKeeSequence  )
+# customisation of the process.
+if options.isMC:
+    from PhysicsTools.BParkingNano.nanoBPark_cff import nanoAOD_customizeMC
+    process = nanoAOD_customizeMC(process)
 
-# process.nanoAOD_step = cms.Path(process.nanoSequence)
+# Path and EndPath definitions
+process.nanoAOD_KMuMu_step = cms.Path(process.nanoSequence + process.nanoBKMuMuSequence + process.nanoSequenceMC)
+process.nanoAOD_Kee_step   = cms.Path(process.nanoSequence + process.nanoBKeeSequence   + process.nanoSequenceMC)
+
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
@@ -129,7 +133,11 @@ process.schedule = cms.Schedule(
                                 process.NANOAODoutput_step
                                )
 if options.wantFullRECO:
-    process.schedule = cms.Schedule(process.nanoAOD_step,process.endjob_step, process.FEVTDEBUGHLToutput_step, process.NANOAODoutput_step)
+    process.schedule = cms.Schedule(process.nanoAOD_KMuMu_step,
+                                    process.nanoAOD_Kee_step, 
+                                    process.endjob_step, 
+                                    process.FEVTDEBUGHLToutput_step, 
+                                    process.NANOAODoutput_step)
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 
@@ -140,11 +148,6 @@ process.NANOAODoutput.SelectEvents = cms.untracked.PSet(
                                    )
 )
     
-# customisation of the process.
-if options.isMC:
-    from PhysicsTools.BParkingNano.nanoBPark_cff import nanoAOD_customizeMC
-    process = nanoAOD_customizeMC(process)
-
 
 process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete

--- a/BParkingNano/test/run_nano_cfg.py
+++ b/BParkingNano/test/run_nano_cfg.py
@@ -112,14 +112,14 @@ process = nanoAOD_customizeElectronFilteredBPark(process)
 process = nanoAOD_customizeTrackFilteredBPark(process)
 process = nanoAOD_customizeBToKLL(process)
 
+# Path and EndPath definitions
+process.nanoAOD_KMuMu_step = cms.Path(process.nanoSequence + process.nanoBKMuMuSequence)
+process.nanoAOD_Kee_step   = cms.Path(process.nanoSequence + process.nanoBKeeSequence  )
+
 # customisation of the process.
 if options.isMC:
     from PhysicsTools.BParkingNano.nanoBPark_cff import nanoAOD_customizeMC
-    process = nanoAOD_customizeMC(process)
-
-# Path and EndPath definitions
-process.nanoAOD_KMuMu_step = cms.Path(process.nanoSequence + process.nanoBKMuMuSequence + process.nanoSequenceMC)
-process.nanoAOD_Kee_step   = cms.Path(process.nanoSequence + process.nanoBKeeSequence   + process.nanoSequenceMC)
+    nanoAOD_customizeMC(process)
 
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
@@ -137,7 +137,8 @@ if options.wantFullRECO:
                                     process.nanoAOD_Kee_step, 
                                     process.endjob_step, 
                                     process.FEVTDEBUGHLToutput_step, 
-                                    process.NANOAODoutput_step)
+                                    process.NANOAODoutput_step
+                                    )
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 


### PR DESCRIPTION
- Added one filter which requires the presence of at least an offline muon matched to a trigger object.
- Moved from one single cms.Path to 2, one for BKee and one for BKmumu, so that is easy to select events with at least N candidates (be it BKmumu or BKee) passing the selection cuts .
By default with this PR, at least 1 candidate is requested.

Running on 500 events, this is what I get:
![nCands_afterFilter](https://user-images.githubusercontent.com/5147955/63267802-1c29e700-c293-11e9-9177-3889b1448ed2.png)
