### PR TITLE
Modify transientTrack building for ele

### DIFF
--- a/BParkingNano/plugins/ElectronMerger.cc
+++ b/BParkingNano/plugins/ElectronMerger.cc
@@ -204,12 +204,6 @@ void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
   }
 
   // build transient track collection
-  // FIXME: this NEEDS to be modified so that the transientTrack is built from the gsfTrack;
-  //        needs modification in transientTrack builders and GsfTransientTrack classes in cmssw 
-  //        already prepared by Arabella but not included here yet in the repo/cmssw. 
-  //        For now using "standard" transientTrack builder just to move on.  
-  //        Also, George here was using ele.bestTrack() instead of ele.gsfTrack()
-  //        https://github.com/CMSBParking/BParkingNANO/blob/410bddcf56b33de73d22f4a6b34fefb588b5b741/BParkingNano/plugins/PreFitter.h#L81 
   for(auto &ele : *ele_out){
     const reco::TransientTrack eleTT =(*theB).buildfromGSF( ele.gsfTrack() );
     trans_ele_out -> emplace_back(eleTT);

--- a/BParkingNano/plugins/ElectronMerger.cc
+++ b/BParkingNano/plugins/ElectronMerger.cc
@@ -211,7 +211,7 @@ void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
   //        Also, George here was using ele.bestTrack() instead of ele.gsfTrack()
   //        https://github.com/CMSBParking/BParkingNANO/blob/410bddcf56b33de73d22f4a6b34fefb588b5b741/BParkingNano/plugins/PreFitter.h#L81 
   for(auto &ele : *ele_out){
-    const reco::TransientTrack eleTT =(*theB).build( ele.gsfTrack() );
+    const reco::TransientTrack eleTT =(*theB).buildfromGSF( ele.gsfTrack() );
     trans_ele_out -> emplace_back(eleTT);
 
     if(ele.userInt("isPF")) continue;

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ git clone --single-branch --branch 102X_LowPtElectrons_2019Jun28 git@github.com:
 mv $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoEgamma/ElectronIdentification/data/LowPtElectrons $CMSSW_BASE/src/RecoEgamma/ElectronIdentification/data # this is required if running on CRAB
 ```
 
+## Add the modification needed to use post-fit quantities for electrons  
+```
+git cms-addpkg TrackingTools/TransientTrack
+git cms-merge-topic CMSBParking:GsfTransientTracks
+```
+
 ## Add the BParkingNano package and build everything
 
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ mv $CMSSW_BASE/external/$SCRAM_ARCH/data/RecoEgamma/ElectronIdentification/data/
 ## Add the modification needed to use post-fit quantities for electrons  
 ```
 git cms-addpkg TrackingTools/TransientTrack
-git cms-merge-topic CMSBParking:GsfTransientTracks
+git cms-merge-topic -u CMSBParking:GsfTransientTracks
 ```
 
 ## Add the BParkingNano package and build everything


### PR DESCRIPTION
Making use of the code provided by Arabella, which is now included in the CMSBParking:GsfTransientTracks branch of cmssw.
Instructions are updated accordingly.