### PR TITLE
fixGen info

### DIFF
--- a/BParkingNano/plugins/CandMCMatchTableProducerBPark.cc
+++ b/BParkingNano/plugins/CandMCMatchTableProducerBPark.cc
@@ -1,0 +1,155 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include <vector>
+#include <iostream>
+
+
+class CandMCMatchTableProducerBPark : public edm::global::EDProducer<> {
+    public:
+        CandMCMatchTableProducerBPark( edm::ParameterSet const & params ) :
+            objName_(params.getParameter<std::string>("objName")),
+            branchName_(params.getParameter<std::string>("branchName")),
+            doc_(params.getParameter<std::string>("docString")),
+            src_(consumes<reco::CandidateView>(params.getParameter<edm::InputTag>("src"))),
+            candMap_(consumes<edm::Association<reco::GenParticleCollection>>(params.getParameter<edm::InputTag>("mcMap")))            
+        {
+            produces<nanoaod::FlatTable>();
+            const std::string & type = params.getParameter<std::string>("objType");
+            if (type == "Muon") type_ = MMuon;
+            else if (type == "Electron") type_ = MElectron;
+            else if (type == "Tau") type_ = MTau;
+            else if (type == "Photon") type_ = MPhoton;
+            else if (type == "ProbeTracks") type_ = MTrack;
+            else if (type == "Other") type_ = MOther;
+            else throw cms::Exception("Configuration", "Unsupported objType '"+type+"'\n");
+    
+	    std::cout << "type = " << type << std::endl;
+            switch(type_) { 
+                case MMuon: flavDoc_ = "1 = prompt muon (including gamma*->mu mu), 15 = muon from prompt tau, " // continues below
+		                       "511 = from B0, 521 = from B+/-, 0 = unknown or unmatched"; break;
+
+	        case MElectron: flavDoc_ = "1 = prompt electron (including gamma*->mu mu), 15 = electron from prompt tau, " // continues below 
+		                           "22 = prompt photon (likely conversion), " // continues below
+		                           "511 = from B0, 521 = from B+/-, 0 = unknown or unmatched"; break;
+                case MPhoton: flavDoc_ = "1 = prompt photon, 13 = prompt electron, 0 = unknown or unmatched"; break;
+                case MTau: flavDoc_    = "1 = prompt electron, 2 = prompt muon, 3 = tau->e decay, 4 = tau->mu decay, 5 = hadronic tau decay, 0 = unknown or unmatched"; break;
+	        case MTrack: flavDoc_  = "1 = prompt, 511 = from B0, 521 = from B+/-, 0 = unknown or unmatched"; break;
+
+                case MOther: flavDoc_  = "1 = from hard scatter, 0 = unknown or unmatched"; break;
+            }
+
+	    if ( type_ == MTau ) {
+	      candMapVisTau_ = consumes<edm::Association<reco::GenParticleCollection>>(params.getParameter<edm::InputTag>("mcMapVisTau"));
+	    }
+        }
+
+        ~CandMCMatchTableProducerBPark() override {}
+
+        void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
+
+            edm::Handle<reco::CandidateView> cands;
+            iEvent.getByToken(src_, cands);
+            unsigned int ncand = cands->size();
+
+            auto tab  = std::make_unique<nanoaod::FlatTable>(ncand, objName_, false, true);
+
+            edm::Handle<edm::Association<reco::GenParticleCollection>> map;
+            iEvent.getByToken(candMap_, map);
+
+	    edm::Handle<edm::Association<reco::GenParticleCollection>> mapVisTau;
+	    if ( type_ == MTau ) {
+	      iEvent.getByToken(candMapVisTau_, mapVisTau);
+	    }
+
+            std::vector<int> key(ncand, -1), flav(ncand, 0);
+            for (unsigned int i = 0; i < ncand; ++i) {
+	      //std::cout << "cand #" << i << ": pT = " << cands->ptrAt(i)->pt() << ", eta = " << cands->ptrAt(i)->eta() << ", phi = " << cands->ptrAt(i)->phi() << std::endl;
+                reco::GenParticleRef match = (*map)[cands->ptrAt(i)];
+		reco::GenParticleRef matchVisTau;
+		if ( type_ == MTau ) {
+		  matchVisTau = (*mapVisTau)[cands->ptrAt(i)];
+		}
+                if      ( match.isNonnull()       ) key[i] = match.key();
+		else if ( matchVisTau.isNonnull() ) key[i] = matchVisTau.key();
+		else continue;
+                switch(type_) {
+                    case MMuon:		        
+                        if (match->isPromptFinalState()) flav[i] = 1; // prompt
+                        else flav[i] = getParentHadronFlag(match); // pdgId of mother
+                        break;
+                    case MElectron:
+                        if (match->isPromptFinalState()) flav[i] = (match->pdgId() == 22 ? 22 : 1); // prompt electron or photon
+                        else flav[i] = getParentHadronFlag(match); // pdgId of mother
+                        break;
+                    case MPhoton:
+                        if (match->isPromptFinalState()) flav[i] = (match->pdgId() == 22 ? 1 : 13); // prompt electron or photon
+                        break;
+                    case MTau:
+		        // CV: assignment of status codes according to https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsToTauTauWorking2016#MC_Matching
+		        if      ( match.isNonnull() && match->statusFlags().isPrompt()                  && abs(match->pdgId()) == 11 ) flav[i] = 1;
+                        else if ( match.isNonnull() && match->statusFlags().isPrompt()                  && abs(match->pdgId()) == 13 ) flav[i] = 2;
+			else if ( match.isNonnull() && match->isDirectPromptTauDecayProductFinalState() && abs(match->pdgId()) == 11 ) flav[i] = 3;
+			else if ( match.isNonnull() && match->isDirectPromptTauDecayProductFinalState() && abs(match->pdgId()) == 13 ) flav[i] = 4;
+			else if ( matchVisTau.isNonnull()                                                                            ) flav[i] = 5;
+                        break;
+		    case MTrack:
+		        if (match->isPromptFinalState()) flav[i] = 1; //prompt
+			else flav[i] = getParentHadronFlag(match); // pdgId of mother
+			break;
+                    default:
+                        flav[i] = match->statusFlags().fromHardProcess();
+                };
+            }    
+            
+            tab->addColumn<int>(branchName_+"Idx",  key, "Index into genParticle list for "+doc_, nanoaod::FlatTable::IntColumn);
+	    //for(auto ij : flav) std::cout << " flav = " << ij << " " << (uint8_t)ij << std::endl;
+            //tab->addColumn<uint8_t>(branchName_+"Flav", flav, "Flavour of genParticle for "+doc_+": "+flavDoc_, nanoaod::FlatTable::UInt8Column);
+	    tab->addColumn<int>(branchName_+"Flav", flav, "Flavour of genParticle for "+doc_+": "+flavDoc_, nanoaod::FlatTable::IntColumn);
+
+            iEvent.put(std::move(tab));
+        }
+
+        static int getParentHadronFlag(const reco::GenParticleRef match) {
+            bool has4 = false;
+            for (unsigned int im = 0, nm = match->numberOfMothers(); im < nm; ++im) {
+                reco::GenParticleRef mom = match->motherRef(im);
+                assert(mom.isNonnull() && mom.isAvailable()); // sanity
+                if (mom.key() >= match.key()) continue; // prevent circular refs
+                int id = std::abs(mom->pdgId());
+		return id;
+            }
+	    return 0;
+        }
+
+        static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+            edm::ParameterSetDescription desc;
+            desc.add<std::string>("objName")->setComment("name of the nanoaod::FlatTable to extend with this table");
+            desc.add<std::string>("branchName")->setComment("name of the column to write (the final branch in the nanoaod will be <objName>_<branchName>Idx and <objName>_<branchName>Flav");
+            desc.add<std::string>("docString")->setComment("documentation to forward to the output");
+            desc.add<edm::InputTag>("src")->setComment("physics object collection for the reconstructed objects (e.g. leptons)");
+            desc.add<edm::InputTag>("mcMap")->setComment("tag to an edm::Association<GenParticleCollection> mapping src to gen, such as the one produced by MCMatcher");
+            desc.add<std::string>("objType")->setComment("type of object to match (Muon, Electron, Tau, Photon, Track, Other), taylors what's in t Flav branch");
+            desc.addOptional<edm::InputTag>("mcMapVisTau")->setComment("as mcMap, but pointing to the visible gen taus (only if objType == Tau)");
+            descriptions.add("candMcMatchTable", desc);
+        }
+
+    protected:
+        const std::string objName_, branchName_, doc_;
+        const edm::EDGetTokenT<reco::CandidateView> src_;
+        const edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> candMap_;
+        edm::EDGetTokenT<edm::Association<reco::GenParticleCollection>> candMapVisTau_;
+        enum MatchType { MMuon, MElectron, MTau, MPhoton, MTrack, MOther } type_;
+        std::string flavDoc_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(CandMCMatchTableProducerBPark);
+

--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -110,7 +110,7 @@ electronsBParkMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, de
     
 )
 
-electronBParkMCTable = cms.EDProducer("CandMCMatchTableProducer",
+electronBParkMCTable = cms.EDProducer("CandMCMatchTableProducerBPark",
     src     = electronBParkTable.src,
     mcMap   = cms.InputTag("electronsBParkMCMatchForTable"),
     objName = electronBParkTable.name,

--- a/BParkingNano/python/genparticlesBPark_cff.py
+++ b/BParkingNano/python/genparticlesBPark_cff.py
@@ -10,21 +10,7 @@ finalGenParticlesBPark = finalGenParticles.clone(
   src = cms.InputTag("mergedGenParticles"),
   select = cms.vstring(
 	"drop *",
-        "keep++ abs(pdgId) == 15 & (pt > 15 ||  isPromptDecayed() )",#  keep full tau decay chain for some taus
-	#"drop status==1 & pt < 1", #drop soft stable particle in tau decay
-        "keep+ abs(pdgId) == 15 ",  #  keep first gen decay product for all tau
-        "+keep pdgId == 22 && status == 1 && (pt > 10 || isPromptFinalState())", # keep gamma above 10 GeV (or all prompt) and its first parent
-	"+keep abs(pdgId) == 11 || abs(pdgId) == 13 || abs(pdgId) == 15", #keep leptons, with at most one mother back in the history
-	"drop abs(pdgId)= 2212 && abs(pz) > 1000", #drop LHC protons accidentally added by previous keeps
-        "keep++ (400 < abs(pdgId) < 600) || (4000 < abs(pdgId) < 6000)", #keep all B and C hadrons + their daughters and granddaughters
-        "keep abs(pdgId) == 12 || abs(pdgId) == 14 || abs(pdgId) == 16",   # keep neutrinos
-	"keep status == 3 || (status > 20 && status < 30)", #keep matrix element summary
-        "keep isHardProcess() ||  fromHardProcessDecayed()  || fromHardProcessFinalState() || (statusFlags().fromHardProcess() && statusFlags().isLastCopy())",  #keep event summary based on status flags
-	"keep  (status > 70 && status < 80 && pt > 15) ", # keep high pt partons right before hadronization
-        "keep abs(pdgId) == 23 || abs(pdgId) == 24 || abs(pdgId) == 25 || abs(pdgId) == 37 ",   # keep VIP(articles)s
-        #"keep abs(pdgId) == 310 && abs(eta) < 2.5 && pt > 1 ",                                                     # keep K0
-        "keep (1000001 <= abs(pdgId) <= 1000039 ) || ( 2000001 <= abs(pdgId) <= 2000015)", #keep SUSY fiction particles
- 		
+        "keep++ (abs(pdgId) == 511 || abs(pdgId) == 521)",  #keep all B0(=511) and B+/-(521) + their daughters and granddaughters
    )
 )
 

--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -87,7 +87,7 @@ muonsBParkMCMatchForTable = cms.EDProducer("MCMatcher",            # cut on delt
     resolveByMatchQuality = cms.bool(True),                   # False = just match input in order; True = pick lowest deltaR pair first
 )
 
-muonBParkMCTable = cms.EDProducer("CandMCMatchTableProducer",
+muonBParkMCTable = cms.EDProducer("CandMCMatchTableProducerBPark",
     src     = muonBParkTable.src,
     mcMap   = cms.InputTag("muonsBParkMCMatchForTable"),
     objName = muonBParkTable.name,

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -58,5 +58,5 @@ def nanoAOD_customizeMC(process):
             pass
 
         path.insert(0, nanoSequenceMC)
-        path.insert(3, muonBParkMC)
+        path.insert(3, muonBParkMC+tracksBParkMC)
 

--- a/BParkingNano/python/tracksBPark_cff.py
+++ b/BParkingNano/python/tracksBPark_cff.py
@@ -50,8 +50,31 @@ trackBParkTable = cms.EDProducer(
 )
 
 
+tracksBParkMCMatchForTable = cms.EDProducer("MCMatcher",   # cut on deltaR, deltaPt/Pt; pick best by deltaR
+    src         = trackBParkTable.src,                     # final reco collection
+    matched     = cms.InputTag("finalGenParticlesBPark"),  # final mc-truth particle collection
+    mcPdgId     = cms.vint32(321,211),                     # one or more PDG ID (321 = charged kaon, 211 = charged pion); absolute values (see below)
+    checkCharge = cms.bool(False),              # True = require RECO and MC objects to have the same charge
+    mcStatus    = cms.vint32(1),                # PYTHIA status code (1 = stable, 2 = shower, 3 = hard scattering)
+    maxDeltaR   = cms.double(0.3),              # Minimum deltaR for the match
+    maxDPtRel   = cms.double(0.5),              # Minimum deltaPt/Pt for the match
+    resolveAmbiguities    = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
+    resolveByMatchQuality = cms.bool(True),     # False = just match input in order; True = pick lowest deltaR pair first
+)
+
+tracksBParkMCTable = cms.EDProducer("CandMCMatchTableProducerBPark",
+    src     = tracksBParkMCMatchForTable.src,
+    mcMap   = cms.InputTag("tracksBParkMCMatchForTable"),
+    objName = trackBParkTable.name,
+    objType = trackBParkTable.name,
+    branchName = cms.string("genPart"),
+    docString = cms.string("MC matching to status==1 kaons or pions"),
+)
+
+
+
 tracksBParkSequence = cms.Sequence(tracksBPark)
 tracksBParkTables = cms.Sequence(trackBParkTable)
-
+tracksBParkMC = cms.Sequence(tracksBParkMCMatchForTable + tracksBParkMCTable)
 
 


### PR DESCRIPTION
This PR
- saves only B0(pdf 511) and B+/-(521) decay chain. 
Any other can be added simply changing 
https://github.com/amartelli/BParkingNANO/blob/02e7a863362845a134b6ffcdc1b2701392fcaf59/BParkingNano/python/genparticlesBPark_cff.py#L13

- the matching of reco Ele, Muons and Tracks is done using the CommonTools/UtilAlgos/interface/PhysObjectMatcher.h package (wrt master, here added the same for tracks)
 * parameters for matching and choice of pdgID in the MC to match the reco particle can be tuned in the respective pythons (ele, muon, tracks)

- the table for the matching saves:
* idx of the genParticle matched
* flavour of the genParticle mother: 0 = unmatched, 1 = prompt, pdgID of the mother otherwise

Tested on MC B->Kmumu and B->JPsimumu and seems reasonable


N.B BParkingNano/plugins/CandMCMatchTableProducerBPark.cc is taken from 
       NanoAOD/plugins/CandMCMatchTableProducer.cc
with the addition of tracks and some changes in the "flav" branch to make it more clear (at least to me) saving directly the pdgId of the mother if available