### PR TITLE
Gen matching cone

### DIFF
--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -105,7 +105,7 @@ electronsBParkMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, de
     mcStatus    = cms.vint32(1),                # PYTHIA status code (1 = stable, 2 = shower, 3 = hard scattering)
     maxDeltaR   = cms.double(0.03),             # Minimum deltaR for the match
     maxDPtRel   = cms.double(0.5),              # Minimum deltaPt/Pt for the match
-    resolveAmbiguities    = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
+    resolveAmbiguities    = cms.bool(False),    # Forbid two RECO objects to match to the same GEN object
     resolveByMatchQuality = cms.bool(True),    # False = just match input in order; True = pick lowest deltaR pair first
     
 )

--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -103,7 +103,7 @@ electronsBParkMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, de
     mcPdgId     = cms.vint32(11,22),                 # one or more PDG ID (11 = el, 22 = pho); absolute values (see below)
     checkCharge = cms.bool(False),              # True = require RECO and MC objects to have the same charge  
     mcStatus    = cms.vint32(1),                # PYTHIA status code (1 = stable, 2 = shower, 3 = hard scattering)
-    maxDeltaR   = cms.double(0.3),              # Minimum deltaR for the match
+    maxDeltaR   = cms.double(0.03),             # Minimum deltaR for the match
     maxDPtRel   = cms.double(0.5),              # Minimum deltaPt/Pt for the match
     resolveAmbiguities    = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
     resolveByMatchQuality = cms.bool(True),    # False = just match input in order; True = pick lowest deltaR pair first

--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -81,7 +81,7 @@ muonsBParkMCMatchForTable = cms.EDProducer("MCMatcher",            # cut on delt
     mcPdgId     = cms.vint32(13),                             # one or more PDG ID (13 = mu); absolute values (see below)
     checkCharge = cms.bool(False),                            # True = require RECO and MC objects to have the same charge
     mcStatus    = cms.vint32(1),                              # PYTHIA status code (1 = stable, 2 = shower, 3 = hard scattering)
-    maxDeltaR   = cms.double(0.3),                            # Minimum deltaR for the match
+    maxDeltaR   = cms.double(0.03),                           # Minimum deltaR for the match
     maxDPtRel   = cms.double(0.5),                            # Minimum deltaPt/Pt for the match
     resolveAmbiguities    = cms.bool(True),                   # Forbid two RECO objects to match to the same GEN object
     resolveByMatchQuality = cms.bool(True),                   # False = just match input in order; True = pick lowest deltaR pair first

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -44,8 +44,8 @@ def nanoAOD_customizeElectronFilteredBPark(process):
     return process
 
 def nanoAOD_customizeBToKLL(process):
-    process.nanoBKeeSequence   = cms.Sequence( process.nanoBKeeSequence + BToKEESequence    + BToKeeTable   )
-    process.nanoBKMuMuSequence = cms.Sequence(                            BToKMuMuSequence  + BToKmumuTable )
+    process.nanoBKeeSequence   = cms.Sequence( BToKEESequence    + BToKeeTable   )
+    process.nanoBKMuMuSequence = cms.Sequence( BToKMuMuSequence  + BToKmumuTable )
     return process
 
 def nanoAOD_customizeMC(process):

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -40,7 +40,7 @@ def nanoAOD_customizeTrackFilteredBPark(process):
     return process
 
 def nanoAOD_customizeElectronFilteredBPark(process):
-    process.nanoBKeeSequence = cms.Sequence( electronsBParkSequence + electronBParkTables)
+    process.nanoSequence = cms.Sequence( process.nanoSequence + electronsBParkSequence + electronBParkTables)
     return process
 
 def nanoAOD_customizeBToKLL(process):

--- a/BParkingNano/python/tracksBPark_cff.py
+++ b/BParkingNano/python/tracksBPark_cff.py
@@ -56,7 +56,7 @@ tracksBParkMCMatchForTable = cms.EDProducer("MCMatcher",   # cut on deltaR, delt
     mcPdgId     = cms.vint32(321,211),                     # one or more PDG ID (321 = charged kaon, 211 = charged pion); absolute values (see below)
     checkCharge = cms.bool(False),              # True = require RECO and MC objects to have the same charge
     mcStatus    = cms.vint32(1),                # PYTHIA status code (1 = stable, 2 = shower, 3 = hard scattering)
-    maxDeltaR   = cms.double(0.3),              # Minimum deltaR for the match
+    maxDeltaR   = cms.double(0.03),             # Minimum deltaR for the match
     maxDPtRel   = cms.double(0.5),              # Minimum deltaPt/Pt for the match
     resolveAmbiguities    = cms.bool(True),     # Forbid two RECO objects to match to the same GEN object
     resolveByMatchQuality = cms.bool(True),     # False = just match input in order; True = pick lowest deltaR pair first


### PR DESCRIPTION
## Motivation
I ran some studies on the matching and it looks like 0.03 is a good choice for everything. I checked the DR of the closest object and the abs(pT - pT_gen)/pT_gen for those matches within 0.03 and everything seems OK.
**Muons:**
![mu_drmin](https://user-images.githubusercontent.com/2329596/64437418-8d0c3400-d0c6-11e9-8feb-5eb338b1704e.png)
![mu_dpt](https://user-images.githubusercontent.com/2329596/64437417-8d0c3400-d0c6-11e9-8cc3-54f5e74bd417.png)

**Electrons:**
![e_drmin](https://user-images.githubusercontent.com/2329596/64437473-9e554080-d0c6-11e9-8d28-efebd6057aac.png)
![e_dpt](https://user-images.githubusercontent.com/2329596/64437472-9e554080-d0c6-11e9-9327-9b09db818f29.png)
 
**Tracks:**
![k_drmin](https://user-images.githubusercontent.com/2329596/64437506-a90fd580-d0c6-11e9-85df-cea3ef5078e1.png)
![k_dpt](https://user-images.githubusercontent.com/2329596/64437504-a90fd580-d0c6-11e9-9157-6ac559a6d7c3.png)

## Changes:
   * Reduce the gen matching cone to 0.03 for all the objects
   * Allow multiple electrons to match the same GEN, this will allow for both lowPt and GSF matches, in case of overlap
   * Minor bugfix in the nano sequence, always run the electrons