### PR TITLE
added MC Match embedding

### DIFF
--- a/BParkingNano/plugins/MatchEmbedder.cc
+++ b/BParkingNano/plugins/MatchEmbedder.cc
@@ -1,0 +1,91 @@
+// Merges the PF and LowPT collections, sets the isPF and isLowPt 
+// UserInt's accordingly
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/View.h"
+
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include <limits>
+#include <algorithm>
+#include "helper.h"
+
+template< typename PATOBJ >
+class MatchEmbedder : public edm::global::EDProducer<> {
+
+  // perhaps we need better structure here (begin run etc)
+
+
+public:
+
+  explicit MatchEmbedder(const edm::ParameterSet &cfg):
+    src_{consumes<PATOBJCollection>(cfg.getParameter<edm::InputTag>("src"))},
+    matching_{consumes< edm::Association<reco::GenParticleCollection> >( cfg.getParameter<edm::InputTag>("matching") )} {
+       produces<PATOBJCollection>();
+    }
+
+  ~MatchEmbedder() override {}
+  
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {}
+  
+private:
+  typedef std::vector<PATOBJ> PATOBJCollection;
+  const edm::EDGetTokenT<PATOBJCollection> src_;
+  const edm::EDGetTokenT< edm::Association<reco::GenParticleCollection> > matching_;
+};
+
+template< typename PATOBJ >
+void MatchEmbedder<PATOBJ>::produce(edm::StreamID, edm::Event &evt, edm::EventSetup const & iSetup) const {
+
+  //input
+  edm::Handle<PATOBJCollection> src;
+  evt.getByToken(src_, src);
+
+  edm::Handle< edm::Association<reco::GenParticleCollection> > matching;
+  evt.getByToken(matching_, matching);
+
+  size_t nsrc = src->size();
+  // output
+  std::unique_ptr<PATOBJCollection>  out(new PATOBJCollection() );
+  out->reserve(nsrc);
+
+  for(unsigned int i = 0; i < nsrc; ++i) {
+    edm::Ptr<PATOBJ> ptr(src, i);
+    reco::GenParticleRef match = (*matching)[ptr];
+    out->emplace_back(src->at(i));
+    out->back().addUserInt(
+      "mcMatch", 
+      match.isNonnull() ? match->pdgId() : 0
+      );
+  }
+  
+  //adding label to be consistent with the muon and track naming
+  evt.put(std::move(out));
+}
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+typedef MatchEmbedder<pat::Muon> MuonMatchEmbedder;
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+typedef MatchEmbedder<pat::Electron> ElectronMatchEmbedder;
+
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+typedef MatchEmbedder<pat::CompositeCandidate> CompositeCandidateMatchEmbedder;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(MuonMatchEmbedder);
+DEFINE_FWK_MODULE(ElectronMatchEmbedder);
+DEFINE_FWK_MODULE(CompositeCandidateMatchEmbedder);

--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -110,6 +110,12 @@ electronsBParkMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, de
     
 )
 
+selectedElectronsMCMatchEmbedded = cms.EDProducer(
+    'ElectronMatchEmbedder',
+    src = electronBParkTable.src,
+    matching = cms.InputTag('electronsBParkMCMatchForTable')
+)
+
 electronBParkMCTable = cms.EDProducer("CandMCMatchTableProducerBPark",
     src     = electronBParkTable.src,
     mcMap   = cms.InputTag("electronsBParkMCMatchForTable"),
@@ -124,9 +130,7 @@ electronsBParkSequence = cms.Sequence(
   lowPtGsfElectronLatestID
   +electronsForAnalysis
 )
-
-
-electronBParkMC = cms.Sequence(electronsBParkMCMatchForTable + electronBParkMCTable)
+electronBParkMC = cms.Sequence(electronsBParkSequence + electronsBParkMCMatchForTable + selectedElectronsMCMatchEmbedded + electronBParkMCTable)
 electronBParkTables = cms.Sequence(electronBParkTable)
 
 

--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -96,7 +96,11 @@ muonBParkMCTable = cms.EDProducer("CandMCMatchTableProducerBPark",
     docString = cms.string("MC matching to status==1 muons"),
 )
 
-
+selectedMuonsMCMatchEmbedded = cms.EDProducer(
+    'MuonMatchEmbedder',
+    src = cms.InputTag('muonTrgSelector:SelectedMuons'),
+    matching = cms.InputTag('muonsBParkMCMatchForTable')
+)
 
 muonTriggerMatchedTable = muonBParkTable.clone(
     src = cms.InputTag("muonTrgSelector:trgMuons"),
@@ -110,9 +114,7 @@ muonTriggerMatchedTable = muonBParkTable.clone(
    )
 )
 
-
-
 muonBParkSequence = cms.Sequence(muonTrgSelector * countTrgMuons)
-muonBParkMC = cms.Sequence(muonsBParkMCMatchForTable + muonBParkMCTable)
+muonBParkMC = cms.Sequence(muonBParkSequence + muonsBParkMCMatchForTable + selectedMuonsMCMatchEmbedded + muonBParkMCTable)
 muonBParkTables = cms.Sequence(muonBParkTable)
 muonTriggerMatchedTables = cms.Sequence(muonTriggerMatchedTable)

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -48,15 +48,16 @@ def nanoAOD_customizeBToKLL(process):
     process.nanoBKMuMuSequence = cms.Sequence( BToKMuMuSequence  + BToKmumuTable )
     return process
 
+from FWCore.ParameterSet.MassReplace import massSearchReplaceAnyInputTag
 def nanoAOD_customizeMC(process):
-    for ipath in process._Process__paths.items():
-        path = process.paths[ipath[0]]
-        try:
-            index  = path.index(process.nanoBKeeSequence)
-            path.insert(index+1, electronBParkMC)
-        except:
-            pass
+    for name, path in process.paths.iteritems():
+        # replace all the non-match embedded inputs with the matched ones
+        massSearchReplaceAnyInputTag(path, 'muonTrgSelector:SelectedMuons', 'selectedMuonsMCMatchEmbedded')
+        massSearchReplaceAnyInputTag(path, 'electronsForAnalysis:SelectedElectrons', 'selectedElectronsMCMatchEmbedded')
+        massSearchReplaceAnyInputTag(path, 'tracksBPark:SelectedTracks', 'tracksBParkMCMatchEmbedded')
 
+        # modify the path to include mc-specific info
         path.insert(0, nanoSequenceMC)
-        path.insert(3, muonBParkMC+tracksBParkMC)
-
+        path.replace(process.muonBParkSequence, process.muonBParkMC)
+        path.replace(process.electronsBParkSequence, process.electronBParkMC)
+        path.replace(process.tracksBParkSequence, process.tracksBParkMC)

--- a/BParkingNano/python/tracksBPark_cff.py
+++ b/BParkingNano/python/tracksBPark_cff.py
@@ -62,6 +62,12 @@ tracksBParkMCMatchForTable = cms.EDProducer("MCMatcher",   # cut on deltaR, delt
     resolveByMatchQuality = cms.bool(True),     # False = just match input in order; True = pick lowest deltaR pair first
 )
 
+tracksBParkMCMatchEmbedded = cms.EDProducer(
+    'CompositeCandidateMatchEmbedder',
+    src = trackBParkTable.src,
+    matching = cms.InputTag("tracksBParkMCMatchForTable")
+)
+
 tracksBParkMCTable = cms.EDProducer("CandMCMatchTableProducerBPark",
     src     = tracksBParkMCMatchForTable.src,
     mcMap   = cms.InputTag("tracksBParkMCMatchForTable"),
@@ -72,9 +78,8 @@ tracksBParkMCTable = cms.EDProducer("CandMCMatchTableProducerBPark",
 )
 
 
-
 tracksBParkSequence = cms.Sequence(tracksBPark)
 tracksBParkTables = cms.Sequence(trackBParkTable)
-tracksBParkMC = cms.Sequence(tracksBParkMCMatchForTable + tracksBParkMCTable)
+tracksBParkMC = cms.Sequence(tracksBParkSequence + tracksBParkMCMatchForTable + tracksBParkMCMatchEmbedded + tracksBParkMCTable)
 
 


### PR DESCRIPTION
This PR adds the GEN match embedding for MC. Tracks, muons, and electrons get a new userInt "mcMatch" that is equal to the pdgID of the matched particle, 0 otherwise.

Locally tested on the MC sample file, does not make any difference in output, as expected.