### PR TITLE
Add tweak to avoid failures in the nanoaodoutput module

### DIFF
--- a/BParkingNano/test/run_nano_cfg.py
+++ b/BParkingNano/test/run_nano_cfg.py
@@ -157,7 +157,9 @@ process.NANOAODoutput.SelectEvents = cms.untracked.PSet(
                                    'nanoAOD_Kee_step'
                                    )
 )
-    
+### from https://hypernews.cern.ch/HyperNews/CMS/get/physics-validation/3287/1/1/1/1/1.html
+process.add_(cms.Service('InitRootHandlers', EnableIMT = cms.untracked.bool(False)))
+process.NANOAODoutput.fakeNameForCrab=cms.untracked.bool(True)    
 
 process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete


### PR DESCRIPTION
Solves jobs failing on crab with error code 139.