### PR TITLE
Do not call rivetLeptonTable

### DIFF
--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -27,7 +27,7 @@ nanoSequence = cms.Sequence(nanoMetadata +
                             triggerObjectBParkTables + l1bits)
 
 nanoSequenceMC = cms.Sequence(particleLevelBParkSequence + genParticleBParkSequence + 
-                              globalTablesMC + genWeightsTable + genParticleBParkTables + particleLevelBParkTables + lheInfoTable) 
+                              globalTablesMC + genWeightsTable + genParticleBParkTables + lheInfoTable) 
 
 
 

--- a/BParkingNano/python/particlelevelBPark_cff.py
+++ b/BParkingNano/python/particlelevelBPark_cff.py
@@ -1,6 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.particlelevel_cff import *
 
-
 particleLevelBParkSequence = cms.Sequence(mergedGenParticles + genParticles2HepMC + particleLevel)
-particleLevelBParkTables = cms.Sequence(rivetLeptonTable)


### PR DESCRIPTION
Do not call rivetLeptonTable, which is not needed, and could cause crashes like the one below.
Probably due to having filtered away the gen particles not coming from B decays.

This change remove the following entries in the ntuples:
*Br  166 :nGenDressedLepton :                                                *
*Br  167 :GenDressedLepton_eta : Float_t eta                                 *
*Br  168 :GenDressedLepton_mass : Float_t mass                               *
*Br  169 :GenDressedLepton_phi : Float_t phi                                 *
*Br  170 :GenDressedLepton_pt : Float_t pt                                   *
*Br  171 :GenDressedLepton_pdgId : Int_t PDG id                              *
*Br  172 :GenDressedLepton_hasTauAnc :                                       *


```
== CMSSW: An exception of category 'ProductNotFound' occurred while
== CMSSW:    [0] Processing  Event run: 1 lumi: 19334 event: 552383031 stream: 0
== CMSSW:    [1] Running path 'nanoAOD_Kee_step'
== CMSSW:    [2] Calling method for module SimpleCandidateFlatTableProducer/'rivetLeptonTable'
== CMSSW: Exception Message:
== CMSSW: Principal::getByToken: Found zero products matching all criteria
== CMSSW: Looking for type: edm::ValueMap<bool>
== CMSSW: Looking for module label: tautagger
== CMSSW: Looking for productInstanceName:

```