### PR TITLE
Save sqrt of uncertainty on 2Dvertex distance

### DIFF
--- a/BParkingNano/plugins/helper.h
+++ b/BParkingNano/plugins/helper.h
@@ -57,7 +57,7 @@ inline Measurement1D l_xy(const FITTER& fitter, const reco::BeamSpot &bs) {
   GlobalError err = fitter.fitted_vtx_uncertainty();
   auto bs_pos = bs.position(point.z());
   GlobalPoint delta(point.x() - bs_pos.x(), point.y() - bs_pos.y(), 0.);  
-  return {delta.perp(), err.rerr(delta)};
+  return {delta.perp(), sqrt(err.rerr(delta))};
 }
 
 


### PR DESCRIPTION
Title says it all.
To be inclued for the next ntuple production (and then we should remember to change the definition of L/sigma in the ntuple reading step).