### PR TITLE
move to KinematicParticleVertexFitter and save refit B mass error

### DIFF
--- a/BParkingNano/plugins/BToKLLBuilder.cc
+++ b/BParkingNano/plugins/BToKLLBuilder.cc
@@ -139,7 +139,8 @@ void BToKLLBuilder::produce(edm::StreamID, edm::Event &evt, edm::EventSetup cons
       cand.addUserFloat("fitted_pt"  , fit_p4.pt()); 
       cand.addUserFloat("fitted_eta" , fit_p4.eta());
       cand.addUserFloat("fitted_phi" , fit_p4.phi());
-      cand.addUserFloat("fitted_mass", fit_p4.mass());      
+      cand.addUserFloat("fitted_mass", fitter.fitted_candidate().mass());      
+      cand.addUserFloat("fitted_massErr", sqrt(fitter.fitted_candidate().kinematicParametersError().matrix()(6,6)));      
       cand.addUserFloat(
         "cos_theta_2D", 
         cos_theta_2D(fitter, *beamspot, cand.p4())

--- a/BParkingNano/plugins/DiLeptonBuilder.cc
+++ b/BParkingNano/plugins/DiLeptonBuilder.cc
@@ -95,6 +95,7 @@ void DiLeptonBuilder<Lepton>::produce(edm::StreamID, edm::Event &evt, edm::Event
       lepton_pair.addUserFloat("sv_ndof", fitter.dof()); // float??
       lepton_pair.addUserFloat("sv_prob", fitter.prob());
       lepton_pair.addUserFloat("fitted_mass", fitter.success() ? fitter.fitted_candidate().mass() : -1);
+      lepton_pair.addUserFloat("fitted_massErr", fitter.success() ? sqrt(fitter.fitted_candidate().kinematicParametersError().matrix()(6,6)) : -1);
       // if needed, add here more stuff
 
       // cut on the SV info

--- a/BParkingNano/plugins/KinVtxFitter.cc
+++ b/BParkingNano/plugins/KinVtxFitter.cc
@@ -1,6 +1,6 @@
 #include "KinVtxFitter.h"
 #include "RecoVertex/KinematicFitPrimitives/interface/KinematicParticleFactoryFromTransientTrack.h"
-#include "RecoVertex/KinematicFit/interface/KinematicConstrainedVertexFitter.h"
+#include "RecoVertex/KinematicFit/interface/KinematicParticleVertexFitter.h"
 #include "RecoVertex/KinematicFit/interface/TwoTrackMassKinematicConstraint.h" // MIGHT be useful for Phi->KK?
 
 KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks, 
@@ -19,7 +19,7 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack> tracks,
       );
   }
 
-  KinematicConstrainedVertexFitter kcv_fitter;    
+  KinematicParticleVertexFitter kcv_fitter;    
   RefCountedKinematicTree vtx_tree = kcv_fitter.fit(particles);
 
   if (vtx_tree->isEmpty() || !vtx_tree->isValid() || !vtx_tree->isConsistent()) {

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -88,12 +88,14 @@ BToKeeTable = cms.EDProducer(
         # Mll
         mll_raw = Var('userCand("dilepton").mass()', float),
         mll_llfit = Var('userCand("dilepton").userFloat("fitted_mass")', float), # this might not work
+        mllErr_llfit = Var('userCand("dilepton").userFloat("fitted_massErr")', float), # this might not work
         mll_fullfit = ufloat('fitted_mll'),
         # Cos(theta)
         cos2D = ufloat('cos_theta_2D'),
         fit_cos2D = ufloat('fitted_cos_theta_2D'),
         # post-fit momentum
         fit_mass = ufloat('fitted_mass'),
+        fit_massErr = ufloat('fitted_massErr'),
         fit_pt = ufloat('fitted_pt'),
         fit_eta = ufloat('fitted_eta'),
         fit_phi = ufloat('fitted_phi'),

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ git cms-addpkg TrackingTools/TransientTrack
 git cms-merge-topic -u CMSBParking:GsfTransientTracks
 ```
 
+## Add the modification needed to use the KinematicParticleVertexFitter  
+```
+git cms-merge-topic -u CMSBParking:fixKinParticleVtxFitter
+```
+
 ## Add the BParkingNano package and build everything
 
 ```


### PR DESCRIPTION
PR to include the commits from Thomas to enable the KinematicParticleVertexFitter.
This used in combination with the ttRefit (for electrons) minimises the failures and provides the best estimate on the refit invariant mass 

Also include extra fixes as in https://github.com/CMSBParking/cmssw/pull/6
to fix some bugs in the covariance matrix definition that also allows to have the error on the refit mass
=> the fitted mass now performs slightly better than the pf p4 sum (in a mass range around the resonance)

All the validation, done on MC JPsi(ee) is documented in the slides:
https://cernbox.cern.ch/index.php/s/oGviT0QS4PJI7df
