### PR TITLE
Save secondary vertex position 

### DIFF
--- a/BParkingNano/plugins/BToKLLBuilder.cc
+++ b/BParkingNano/plugins/BToKLLBuilder.cc
@@ -151,6 +151,12 @@ void BToKLLBuilder::produce(edm::StreamID, edm::Event &evt, edm::EventSetup cons
       auto lxy = l_xy(fitter, *beamspot);
       cand.addUserFloat("l_xy", lxy.value());
       cand.addUserFloat("l_xy_unc", lxy.error());
+      cand.addUserFloat("vtx_x", cand.vx());
+      cand.addUserFloat("vtx_y", cand.vy());
+      cand.addUserFloat("vtx_z", cand.vz());
+      cand.addUserFloat("vtx_ex", sqrt(fitter.fitted_vtx_uncertainty().cxx()));
+      cand.addUserFloat("vtx_ey", sqrt(fitter.fitted_vtx_uncertainty().cyy()));
+      cand.addUserFloat("vtx_ez", sqrt(fitter.fitted_vtx_uncertainty().czz()));
     
       if( !post_vtx_selection_(cand) ) continue;        
       ret_val->push_back(cand);

--- a/BParkingNano/plugins/helper.h
+++ b/BParkingNano/plugins/helper.h
@@ -57,7 +57,7 @@ inline Measurement1D l_xy(const FITTER& fitter, const reco::BeamSpot &bs) {
   GlobalError err = fitter.fitted_vtx_uncertainty();
   auto bs_pos = bs.position(point.z());
   GlobalPoint delta(point.x() - bs_pos.x(), point.y() - bs_pos.y(), 0.);  
-  return {delta.perp(), sqrt(err.rerr(delta))};
+  return {delta.perp(), err.rerr(delta)};
 }
 
 

--- a/BParkingNano/plugins/helper.h
+++ b/BParkingNano/plugins/helper.h
@@ -57,7 +57,7 @@ inline Measurement1D l_xy(const FITTER& fitter, const reco::BeamSpot &bs) {
   GlobalError err = fitter.fitted_vtx_uncertainty();
   auto bs_pos = bs.position(point.z());
   GlobalPoint delta(point.x() - bs_pos.x(), point.y() - bs_pos.y(), 0.);  
-  return {delta.perp(), err.rerr(delta)};
+  return {delta.perp(), sqrt(err.rerr(delta))};
 }
 
 

--- a/BParkingNano/python/BToKLL_cff.py
+++ b/BParkingNano/python/BToKLL_cff.py
@@ -85,6 +85,12 @@ BToKeeTable = cms.EDProducer(
         svprob = ufloat('sv_prob'),
         l_xy = ufloat('l_xy'),
         l_xy_unc = ufloat('l_xy_unc'),
+        vtx_x = ufloat('vtx_x'),
+        vtx_y = ufloat('vtx_y'),
+        vtx_z = ufloat('vtx_z'),
+        vtx_ex = ufloat('vtx_ex'), ## only saving diagonal elements of the cov matrix
+        vtx_ey = ufloat('vtx_ey'),
+        vtx_ez = ufloat('vtx_ez'),
         # Mll
         mll_raw = Var('userCand("dilepton").mass()', float),
         mll_llfit = Var('userCand("dilepton").userFloat("fitted_mass")', float), # this might not work

--- a/BParkingNano/python/genparticlesBPark_cff.py
+++ b/BParkingNano/python/genparticlesBPark_cff.py
@@ -15,8 +15,16 @@ finalGenParticlesBPark = finalGenParticles.clone(
 )
 
 genParticleBParkTable = genParticleTable.clone(
-  src = cms.InputTag("finalGenParticlesBPark")
+  src = cms.InputTag("finalGenParticlesBPark"),
+  variables = cms.PSet(
+      genParticleTable.variables,
+      vx = Var("vx()", float, doc="x coordinate of the production vertex position, in cm", precision=10),
+      vy = Var("vy()", float, doc="y coordinate of the production vertex position, in cm", precision=10),
+      vz = Var("vz()", float, doc="z coordinate of the production vertex position, in cm", precision=10),
+  )
 )
+
+
 
 genParticleBParkSequence = cms.Sequence(finalGenParticlesBPark)
 genParticleBParkTables = cms.Sequence(genParticleBParkTable)


### PR DESCRIPTION
Save SV position and its uncertainty (diagonal element only) for reco BKll candidate.
Save production vtx position for GEN particles.