### PR TITLE
add old MC Kmumu sample with pT cut not imposed on tag side

### DIFF
--- a/BParkingNano/production/samples.yml
+++ b/BParkingNano/production/samples.yml
@@ -67,6 +67,10 @@ samples:
     dataset: /BuToKJpsi_Toee_Mufilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18MiniAOD-PUPoissonAve20_BParking_102X_upgrade2018_realistic_v15-v2/MINIAODSIM 
     isMC: True
     
+  BuToKMuMu_v0:
+    dataset: /BuToK_ToMuMu_MuFilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18MiniAOD-PUPoissonAve20_102X_upgrade2018_realistic_v15-v2/MINIAODSIM
+    isMC: True
+
   BuToKMuMu:
     dataset: /BuToKMuMu_probefilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18MiniAOD-PUPoissonAve20_BParking_102X_upgrade2018_realistic_v15-v2/MINIAODSIM 
     isMC: True
@@ -78,7 +82,6 @@ samples:
   BuToKee:
     dataset: /BuToKee_Mufilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18MiniAOD-PUPoissonAve20_BParking_102X_upgrade2018_realistic_v15_ext1-v2/MINIAODSIM
     isMC: True
-
 
   BdToKstarJpsi_ToMuMu:
     dataset: /BdToKstarJpsi_ToKPiMuMu_probefilter_SoftQCDnonD_TuneCP5_13TeV-pythia8-evtgen/RunIIAutumn18MiniAOD-PUPoissonAve20_BParking_102X_upgrade2018_realistic_v15-v2/MINIAODSIM 


### PR DESCRIPTION
From my record this is the old MC sample where the pT requirement on the trigger muon
was not forced on the tag side. 
So adding a proper selection at analysis level will reduce the available stat, but probably still worth adding as much MC as possible?
