### PR TITLE
getUsernameFromSiteDB deprecated

### DIFF
--- a/BParkingNano/production/submit_on_crab.py
+++ b/BParkingNano/production/submit_on_crab.py
@@ -1,4 +1,4 @@
-from CRABClient.UserUtilities import config, ClientException, getUsernameFromSiteDB
+from CRABClient.UserUtilities import config, ClientException, getUsernameFromCRIC
 #from input_crab_data import dataset_files
 import yaml
 import datetime


### PR DESCRIPTION
`getUsernameFromSiteDB` no longer works, as https://cmsweb.cern.ch/sitedb has been deactivated (https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/5576.html).  The replacement is`getUsernameFromCRIC`, which works identically as far as I can tell.