### PR TITLE
Match electrons to photon conversion tracks

### DIFF
--- a/BParkingNano/plugins/BuildFile.xml
+++ b/BParkingNano/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="DataFormats/PatCandidates"/>
 <use   name="CommonTools/Utils"/>
 <use   name="CommonTools/CandAlgos"/>
+<use   name="CommonTools/Statistics"/>
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="PhysicsTools/JetMCUtils"/>
 <use   name="DataFormats/NanoAOD"/>
@@ -24,6 +25,8 @@
 <use   name="TrackingTools/Records"/>
 <use   name="TrackingTools/IPTools"/>
 <use   name="TrackingTools/GsfTracking"/>
+<use   name="DataFormats/EgammaCandidates"/>
+<use   name="DataFormats/BeamSpot"/>
 <!--flags CXXFLAGS="-g"/-->  
 <library   file="*.cc" name="PhysicsToolsBParkingNanoPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/BParkingNano/plugins/ConversionInfo.cc
+++ b/BParkingNano/plugins/ConversionInfo.cc
@@ -1,0 +1,168 @@
+#include "ConversionInfo.h"
+
+////////////////////////////////////////////////////////////////////////////////
+// Nancy's baseline selections for conversions
+bool ConversionInfo::wpLoose() {
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Nancy's selection for analysis of conversions
+bool ConversionInfo::wpTight() {
+  return true;
+}
+    
+////////////////////////////////////////////////////////////////////////////////
+//
+void ConversionInfo::addExtraUserVars() {
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+bool ConversionInfo::match(const edm::Handle<reco::BeamSpot>& beamSpot,
+			   const edm::Handle<edm::View<reco::Conversion> >& conversions,
+			   const pat::Electron& ele) {
+  ConversionInfo info;
+  return ConversionInfo::match(beamSpot,conversions,ele,info);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+bool ConversionInfo::match(const edm::Handle<reco::BeamSpot>& beamSpot,
+			   const edm::Handle<edm::View<reco::Conversion> >& conversions,
+			   const pat::Electron& ele,
+			   ConversionInfo& info) {
+  
+  bool matched = false;
+  
+  // Valid handles?
+  if ( !(beamSpot.isValid()) ) {
+    edm::LogError("ConversionInfo::match")
+      << " !(beamSpot.isValid())" << std::endl;
+    return false;
+  }
+  if ( !(conversions.isValid()) ) {
+    edm::LogError("ConversionInfo::match")
+      << " !(conversions.isValid())" << std::endl;
+    return false;
+  }
+  
+  // Iterate through conversions and calculate quantities (requirement from Nancy)
+  for ( const auto& conv : *conversions ) {
+
+    // Filter
+    if ( conv.tracks().size() != 2 ) { continue; }
+
+    // Quality
+    info.valid = conv.conversionVertex().isValid(); // (=true)
+    info.chi2prob = ChiSquaredProbability(conv.conversionVertex().chi2(),conv.conversionVertex().ndof()); // (<0.005)
+    info.quality_high_purity = conv.quality(reco::Conversion::highPurity); // (=true)
+    info.quality_high_efficiency = conv.quality(reco::Conversion::highEfficiency); // (none)
+
+    // Tracks
+    info.ntracks = conv.tracks().size(); // (=2)
+    info.min_trk_pt = -1.; // (>0.5)
+    for ( const auto& trk : conv.tracks() ) {
+      if ( info.min_trk_pt < 0. || trk->pt() < info.min_trk_pt ) { info.min_trk_pt = trk->pt(); }
+    }
+    info.ilead = -1; info.itrail = -1;
+    if ( conv.tracks().size() == 2 ) {
+      edm::RefToBase<reco::Track> trk1 = conv.tracks().front();
+      edm::RefToBase<reco::Track> trk2 = conv.tracks().back();
+      if      ( trk1->pt() > trk2->pt() ) { info.ilead = 0; info.itrail = 1; }
+      else if ( trk1->pt() < trk2->pt() ) { info.ilead = 1; info.itrail = 0; }
+    }
+
+    // Transverse displacement (with respect to beamspot) and vertex radius
+    math::XYZVectorF p_refitted =  conv.refittedPairMomentum();
+    float dx = conv.conversionVertex().x() - beamSpot->x0();
+    float dy = conv.conversionVertex().y() - beamSpot->y0();
+    info.l_xy = (p_refitted.x()*dx + p_refitted.y()*dy) / p_refitted.rho();
+    info.vtx_radius = sqrt(conv.conversionVertex().position().perp2()); // (1.5<r<4.)
+
+    // invariant mass from track pair from conversion
+    info.mass_from_conv = conv.pairInvariantMass();
+    
+    // Invariant mass from Pin before fit to common vertex 
+    if ( conv.tracksPin().size() >= 2 ) {
+      math::XYZVectorF lead_Pin = conv.tracksPin().at(info.ilead);
+      math::XYZVectorF trail_Pin = conv.tracksPin().at(info.itrail);
+      info.mass_from_Pin = mee( lead_Pin.x(), lead_Pin.y(), lead_Pin.z(),
+				trail_Pin.x(), trail_Pin.y(), trail_Pin.z() );
+      // Opening angle
+      info.delta_cot_from_Pin = 1. / tan(trail_Pin.theta()) - 1. / tan(lead_Pin.theta());
+    }
+
+    // Invariant mass before fit to common vertex
+    if ( conv.tracks().size() >= 2 ) {
+      edm::RefToBase<reco::Track> lead_before_vtx_fit = conv.tracks().at(info.ilead);
+      edm::RefToBase<reco::Track> trail_before_vtx_fit = conv.tracks().at(info.itrail);
+      info.mass_before_fit = mee( lead_before_vtx_fit->px(), lead_before_vtx_fit->py(), lead_before_vtx_fit->pz(),
+				  trail_before_vtx_fit->px(), trail_before_vtx_fit->py(), trail_before_vtx_fit->pz() );
+    }
+
+    // Invariant mass after the fit to common vertex
+    if ( conv.conversionVertex().refittedTracks().size() >=2 ) {
+      const reco::Track lead_after_vtx_fit = conv.conversionVertex().refittedTracks().at(info.ilead);
+      const reco::Track trail_after_vtx_fit = conv.conversionVertex().refittedTracks().at(info.itrail);
+      info.mass_after_fit = mee( lead_after_vtx_fit.px(), lead_after_vtx_fit.py(), lead_after_vtx_fit.pz(),
+				 trail_after_vtx_fit.px(), trail_after_vtx_fit.py(), trail_after_vtx_fit.pz());
+      // Difference in expeted hits
+      info.delta_expected_nhits_inner =
+	lead_after_vtx_fit.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
+	- trail_after_vtx_fit.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+    }
+    
+    // Hits prior to vertex
+    info.lead_nhits_before_vtx  = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(info.ilead) : 0;
+    info.trail_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(info.itrail) : 0;
+    info.max_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
+      ( conv.nHitsBeforeVtx().at(0) > conv.nHitsBeforeVtx().at(1) ?
+	conv.nHitsBeforeVtx().at(0) :
+	conv.nHitsBeforeVtx().at(1) ) : 0;
+    info.sum_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
+      conv.nHitsBeforeVtx().at(0) +
+      conv.nHitsBeforeVtx().at(1) : 0;
+    
+    // Attempt to match conversion track to electron
+    for ( uint itrk = 0; itrk < conv.tracks().size(); ++itrk ) {
+
+      edm::RefToBase<reco::Track> trk = conv.tracks()[itrk];
+      if ( trk.isNull() ) { continue; }
+      
+      reco::GsfTrackRef gsf = ele.gsfTrack();
+      if ( gsf.isNull() ) { continue; }
+
+      if ( gsf.id() == trk.id() && gsf.key() == trk.key() )  { 
+	if ( (int)itrk == info.ilead ) {
+	  info.matched_lead = trk;
+	  matched = true;
+	}
+	if ( (int)itrk == info.itrail ) {
+	  info.matched_trail = trk;
+	  matched = true;
+	}
+      }
+      
+    } // track loop
+    
+  } // conversions loop
+
+  return matched;
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+float ConversionInfo::mee(float ipx1, float ipy1, float ipz1, 
+			  float ipx2, float ipy2, float ipz2) {
+  const float  m = 0.000511;
+  const float px = ipx1+ipx2;
+  const float py = ipy1+ipy2;
+  const float pz = ipz1+ipz2;
+  const float p1 = ipx1*ipx1 + ipy1*ipy1 + ipz1*ipz1;
+  const float p2 = ipx2*ipx2 + ipy2*ipy2 + ipz2*ipz2;
+  const float  e = sqrt( p1 + m*m ) + sqrt( p2 + m*m );
+  const float mass = ( e*e - px*px - py*py - pz*pz );
+  return mass > 0. ? sqrt(mass) : -1.;
+}

--- a/BParkingNano/plugins/ConversionInfo.h
+++ b/BParkingNano/plugins/ConversionInfo.h
@@ -11,19 +11,21 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 class ConversionInfo {
-
-public:
-
+  
+ public:
+  
   ConversionInfo() {;}
   ~ConversionInfo() {;}
-
+  
   void reset() { ConversionInfo dummy; *this = dummy; }
-
+  
+  bool wpOpen();  // Matched to any conversion (without selections)
   bool wpLoose(); // Nancy's baseline selections for conversions
   bool wpTight(); // Nancy's selection for analysis of conversions
-
-  void addExtraUserVars();
-
+  
+  void addUserVars(pat::Electron& ele); // adds minimal set of flags to electron userData
+  void addUserVarsExtra(pat::Electron& ele); // adds all variables to electron userData
+  
   static bool match(const edm::Handle<reco::BeamSpot>& beamSpot,
 		    const edm::Handle<edm::View<reco::Conversion> >& conversions,
 		    const pat::Electron& ele);
@@ -70,7 +72,8 @@ public:
   // opening angle
   float delta_cot_from_Pin = -1.;
 
-  // matched tracks
+  // match?
+  bool matched = false;
   edm::RefToBase<reco::Track> matched_lead;
   edm::RefToBase<reco::Track> matched_trail;
   

--- a/BParkingNano/plugins/ConversionInfo.h
+++ b/BParkingNano/plugins/ConversionInfo.h
@@ -1,0 +1,79 @@
+#ifndef ConversionInfo_h
+#define ConversionInfo_h
+
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+class ConversionInfo {
+
+public:
+
+  ConversionInfo() {;}
+  ~ConversionInfo() {;}
+
+  void reset() { ConversionInfo dummy; *this = dummy; }
+
+  bool wpLoose(); // Nancy's baseline selections for conversions
+  bool wpTight(); // Nancy's selection for analysis of conversions
+
+  void addExtraUserVars();
+
+  static bool match(const edm::Handle<reco::BeamSpot>& beamSpot,
+		    const edm::Handle<edm::View<reco::Conversion> >& conversions,
+		    const pat::Electron& ele);
+  
+  static bool match(const edm::Handle<reco::BeamSpot>& beamSpot,
+		    const edm::Handle<edm::View<reco::Conversion> >& conversions,
+		    const pat::Electron& ele,
+		    ConversionInfo& info);
+  
+  static float mee(float ipx1, float ipy1, float ipz1, 
+		   float ipx2, float ipy2, float ipz2);
+
+public:
+
+  // quality
+  bool valid = false;
+  float chi2prob = -1.;
+  bool quality_high_purity = false;
+  bool quality_high_efficiency = false;
+
+  // tracks
+  uint ntracks = 0;
+  float min_trk_pt = -1.;
+  int ilead = -1;
+  int itrail = -1;
+
+  // displacement
+  float l_xy = -1.;
+  float vtx_radius = -1.;
+
+  // invariant mass
+  float mass_from_conv = -1.;
+  float mass_from_Pin = -1.;
+  float mass_before_fit = -1.;
+  float mass_after_fit = -1.;
+
+  // hits before vertex
+  uint lead_nhits_before_vtx = 0;
+  uint trail_nhits_before_vtx = 0;
+  uint max_nhits_before_vtx = 0;
+  uint sum_nhits_before_vtx = 0;
+  int delta_expected_nhits_inner = 0;
+
+  // opening angle
+  float delta_cot_from_Pin = -1.;
+
+  // matched tracks
+  edm::RefToBase<reco::Track> matched_lead;
+  edm::RefToBase<reco::Track> matched_trail;
+  
+};
+
+#endif // ConversionInfo_h

--- a/BParkingNano/plugins/ElectronMerger.cc
+++ b/BParkingNano/plugins/ElectronMerger.cc
@@ -290,7 +290,7 @@ void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
    ConversionInfo::match(beamSpot,conversions,ele,info);
    info.addUserVars(ele);
    if ( addUserVarsExtra_ ) { info.addUserVarsExtra(ele); }
-   if (/*debug && */info.matched) { 
+   if (debug && info.wpOpen()) { 
      std::cout << "[ElectronMerger::produce]"
 	       << " iele: " << iele
 	       << ", convOpen: " << (info.wpOpen()?1:0)

--- a/BParkingNano/plugins/ElectronMerger.cc
+++ b/BParkingNano/plugins/ElectronMerger.cc
@@ -12,7 +12,6 @@
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 
-#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
@@ -21,49 +20,11 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "ConversionInfo.h"
 
 #include <limits>
 #include <algorithm>
 #include "helper.h"
-
-class ConversionInfo {
-public:
-
-  ConversionInfo() {;}
-  ~ConversionInfo() {;}
-  void reset() { ConversionInfo dummy; *this = dummy; }
-
-  // quality
-  bool valid = false;
-  float chi2prob = -1.;
-  bool quality_high_purity = false;
-  bool quality_high_efficiency = false;
-  // tracks
-  uint ntracks = 0;
-  float min_trk_pt = -1.;
-  int ilead = -1;
-  int itrail = -1;
-  // displacement
-  float l_xy = -1.;
-  float vtx_radius = -1.;
-  // invariant mass
-  float mass_from_conv = -1.;
-  float mass_from_Pin = -1.;
-  float mass_before_fit = -1.;
-  float mass_after_fit = -1.;
-  // hits before vertex
-  uint lead_nhits_before_vtx = 0;
-  uint trail_nhits_before_vtx = 0;
-  uint max_nhits_before_vtx = 0;
-  uint sum_nhits_before_vtx = 0;
-  int delta_expected_nhits_inner = 0;
-  // opening angle
-  float delta_cot_from_Pin = -1.;
-  // matched tracks
-  edm::RefToBase<reco::Track> matched_lead;
-  edm::RefToBase<reco::Track> matched_trail;
-  
-};
 
 class ElectronMerger : public edm::global::EDProducer<> {
 
@@ -107,18 +68,6 @@ public:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions) {}
-
-  bool matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
-			       const edm::Handle<edm::View<reco::Conversion> >& conversions,
-			       const pat::Electron& ele) const;
-  
-  bool matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
-			       const edm::Handle<edm::View<reco::Conversion> >& conversions,
-			       const pat::Electron& ele,
-			       ConversionInfo& info) const;
-  
-  float mee(float ipx1, float ipy1, float ipz1, 
-	    float ipx2, float ipy2, float ipz2) const;
   
 private:
   const edm::EDGetTokenT<pat::MuonCollection> triggerMuons_;
@@ -286,10 +235,11 @@ void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
 
    // Match to tracks in "gsfTracksOpenConversions" collection
    ConversionInfo info;
-   bool matched = matchToConversionTracks(beamSpot,conversions,ele,info);
+   bool matched = ConversionInfo::match(beamSpot,conversions,ele,info);
    ele.addUserInt("isConversion", matched?1:0);
    ele.addUserInt("convLeadTrack", info.matched_lead.isNonnull()?1:0);
    ele.addUserInt("convTrailTrack", info.matched_trail.isNonnull()?1:0);
+   info.addExtraUserVars();
 
    if (/*debug && */matched) {
      std::cout << "[ElectronMerger::produce]"
@@ -384,150 +334,6 @@ void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
   //adding label to be consistent with the muon and track naming
   evt.put(std::move(ele_out),      "SelectedElectrons");
   evt.put(std::move(trans_ele_out),"SelectedTransientElectrons");
-}
-
-bool ElectronMerger::matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
-					     const edm::Handle<edm::View<reco::Conversion> >& conversions,
-					     const pat::Electron& ele) const {
-  ConversionInfo info;
-  return matchToConversionTracks(beamSpot,conversions,ele,info);
-}
-
-bool ElectronMerger::matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
-					     const edm::Handle<edm::View<reco::Conversion> >& conversions,
-					     const pat::Electron& ele,
-					     ConversionInfo& info) const {
-  
-  bool matched = false;
-
-  // Valid handles?
-  if ( !(beamSpot.isValid()) ) {
-    edm::LogError("ElectronMerger::matchToConversionTracks")
-      << " !(beamSpot.isValid())" << std::endl;
-    return false;
-  }
-  if ( !(conversions.isValid()) ) {
-    edm::LogError("ElectronMerger::matchToConversionTracks")
-      << " !(conversions.isValid())" << std::endl;
-    return false;
-  }
-  
-  // Iterate through conversions and calculate quantities (requirement from Nancy)
-  for ( const auto& conv : *conversions ) {
-
-    // Filter
-    if ( conv.tracks().size() != 2 ) { continue; }
-
-    // Quality
-    info.valid = conv.conversionVertex().isValid(); // (=true)
-    info.chi2prob = ChiSquaredProbability(conv.conversionVertex().chi2(),conv.conversionVertex().ndof()); // (<0.005)
-    info.quality_high_purity = conv.quality(reco::Conversion::highPurity); // (=true)
-    info.quality_high_efficiency = conv.quality(reco::Conversion::highEfficiency); // (none)
-
-    // Tracks
-    info.ntracks = conv.tracks().size(); // (=2)
-    info.min_trk_pt = -1.; // (>0.5)
-    for ( const auto& trk : conv.tracks() ) {
-      if ( info.min_trk_pt < 0. || trk->pt() < info.min_trk_pt ) { info.min_trk_pt = trk->pt(); }
-    }
-    info.ilead = -1; info.itrail = -1;
-    if ( conv.tracks().size() == 2 ) {
-      edm::RefToBase<reco::Track> trk1 = conv.tracks().front();
-      edm::RefToBase<reco::Track> trk2 = conv.tracks().back();
-      if      ( trk1->pt() > trk2->pt() ) { info.ilead = 0; info.itrail = 1; }
-      else if ( trk1->pt() < trk2->pt() ) { info.ilead = 1; info.itrail = 0; }
-    }
-
-    // Transverse displacement (with respect to beamspot) and vertex radius
-    math::XYZVectorF p_refitted =  conv.refittedPairMomentum();
-    float dx = conv.conversionVertex().x() - beamSpot->x0();
-    float dy = conv.conversionVertex().y() - beamSpot->y0();
-    info.l_xy = (p_refitted.x()*dx + p_refitted.y()*dy) / p_refitted.rho();
-    info.vtx_radius = sqrt(conv.conversionVertex().position().perp2()); // (1.5<r<4.)
-
-    // invariant mass from track pair from conversion
-    info.mass_from_conv = conv.pairInvariantMass();
-    
-    // Invariant mass from Pin before fit to common vertex 
-    if ( conv.tracksPin().size() >= 2 ) {
-      math::XYZVectorF lead_Pin = conv.tracksPin().at(info.ilead);
-      math::XYZVectorF trail_Pin = conv.tracksPin().at(info.itrail);
-      info.mass_from_Pin = mee( lead_Pin.x(), lead_Pin.y(), lead_Pin.z(),
-				trail_Pin.x(), trail_Pin.y(), trail_Pin.z() );
-      // Opening angle
-      info.delta_cot_from_Pin = 1. / tan(trail_Pin.theta()) - 1. / tan(lead_Pin.theta());
-    }
-
-    // Invariant mass before fit to common vertex
-    if ( conv.tracks().size() >= 2 ) {
-      edm::RefToBase<reco::Track> lead_before_vtx_fit = conv.tracks().at(info.ilead);
-      edm::RefToBase<reco::Track> trail_before_vtx_fit = conv.tracks().at(info.itrail);
-      info.mass_before_fit = mee( lead_before_vtx_fit->px(), lead_before_vtx_fit->py(), lead_before_vtx_fit->pz(),
-				  trail_before_vtx_fit->px(), trail_before_vtx_fit->py(), trail_before_vtx_fit->pz() );
-    }
-
-    // Invariant mass after the fit to common vertex
-    if ( conv.conversionVertex().refittedTracks().size() >=2 ) {
-      const reco::Track lead_after_vtx_fit = conv.conversionVertex().refittedTracks().at(info.ilead);
-      const reco::Track trail_after_vtx_fit = conv.conversionVertex().refittedTracks().at(info.itrail);
-      info.mass_after_fit = mee( lead_after_vtx_fit.px(), lead_after_vtx_fit.py(), lead_after_vtx_fit.pz(),
-				 trail_after_vtx_fit.px(), trail_after_vtx_fit.py(), trail_after_vtx_fit.pz());
-      // Difference in expeted hits
-      info.delta_expected_nhits_inner =
-	lead_after_vtx_fit.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
-	- trail_after_vtx_fit.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-    }
-    
-    // Hits prior to vertex
-    info.lead_nhits_before_vtx  = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(info.ilead) : 0;
-    info.trail_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(info.itrail) : 0;
-    info.max_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
-      ( conv.nHitsBeforeVtx().at(0) > conv.nHitsBeforeVtx().at(1) ?
-	conv.nHitsBeforeVtx().at(0) :
-	conv.nHitsBeforeVtx().at(1) ) : 0;
-    info.sum_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
-      conv.nHitsBeforeVtx().at(0) +
-      conv.nHitsBeforeVtx().at(1) : 0;
-    
-    // Attempt to match conversion track to electron
-    for ( uint itrk = 0; itrk < conv.tracks().size(); ++itrk ) {
-
-      edm::RefToBase<reco::Track> trk = conv.tracks()[itrk];
-      if ( trk.isNull() ) { continue; }
-      
-      reco::GsfTrackRef gsf = ele.gsfTrack();
-      if ( gsf.isNull() ) { continue; }
-
-      if ( gsf.id() == trk.id() && gsf.key() == trk.key() )  { 
-	if ( (int)itrk == info.ilead ) {
-	  info.matched_lead = trk;
-	  matched = true;
-	}
-	if ( (int)itrk == info.itrail ) {
-	  info.matched_trail = trk;
-	  matched = true;
-	}
-      }
-      
-    } // track loop
-    
-  } // conversions loop
-
-  return matched;
-
-}
-
-float ElectronMerger::mee(float ipx1, float ipy1, float ipz1, 
-			  float ipx2, float ipy2, float ipz2) const {
-  const float  m = 0.000511;
-  const float px = ipx1+ipx2;
-  const float py = ipy1+ipy2;
-  const float pz = ipz1+ipz2;
-  const float p1 = ipx1*ipx1 + ipy1*ipy1 + ipz1*ipz1;
-  const float p2 = ipx2*ipx2 + ipy2*ipy2 + ipz2*ipz2;
-  const float  e = sqrt( p1 + m*m ) + sqrt( p2 + m*m );
-  const float mass = ( e*e - px*px - py*py - pz*pz );
-  return mass > 0. ? sqrt(mass) : -1.;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/BParkingNano/plugins/ElectronMerger.cc
+++ b/BParkingNano/plugins/ElectronMerger.cc
@@ -26,6 +26,45 @@
 #include <algorithm>
 #include "helper.h"
 
+class ConversionInfo {
+public:
+
+  ConversionInfo() {;}
+  ~ConversionInfo() {;}
+  void reset() { ConversionInfo dummy; *this = dummy; }
+
+  // quality
+  bool valid = false;
+  float chi2prob = -1.;
+  bool quality_high_purity = false;
+  bool quality_high_efficiency = false;
+  // tracks
+  uint ntracks = 0;
+  float min_trk_pt = -1.;
+  int ilead = -1;
+  int itrail = -1;
+  // displacement
+  float l_xy = -1.;
+  float vtx_radius = -1.;
+  // invariant mass
+  float mass_from_conv = -1.;
+  float mass_from_Pin = -1.;
+  float mass_before_fit = -1.;
+  float mass_after_fit = -1.;
+  // hits before vertex
+  uint lead_nhits_before_vtx = 0;
+  uint trail_nhits_before_vtx = 0;
+  uint max_nhits_before_vtx = 0;
+  uint sum_nhits_before_vtx = 0;
+  int delta_expected_nhits_inner = 0;
+  // opening angle
+  float delta_cot_from_Pin = -1.;
+  // matched tracks
+  edm::RefToBase<reco::Track> matched_lead;
+  edm::RefToBase<reco::Track> matched_trail;
+  
+};
+
 class ElectronMerger : public edm::global::EDProducer<> {
 
   // perhaps we need better structure here (begin run etc)
@@ -71,45 +110,13 @@ public:
 
   bool matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
 			       const edm::Handle<edm::View<reco::Conversion> >& conversions,
-			       const pat::Electron& ele,
-			       edm::RefToBase<reco::Track>& matched_lead,					     
-			       edm::RefToBase<reco::Track>& matched_trail
-			       ) const;
-
+			       const pat::Electron& ele) const;
+  
   bool matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
 			       const edm::Handle<edm::View<reco::Conversion> >& conversions,
 			       const pat::Electron& ele,
-			       // quality
-			       bool& valid,
-			       float& chi2prob,
-			       bool& quality_high_purity,
-			       bool& quality_high_efficiency,
-			       // tracks
-			       uint& ntracks,
-			       float& min_trk_pt,
-			       int& ilead,
-			       int& itrail,
-			       // displacement
-			       float& l_xy,
-			       float& vtx_radius,
-			       // invariant mass
-			       float& mass_from_conv,
-			       float& mass_from_Pin,
-			       float& mass_before_fit,
-			       float& mass_after_fit,
-			       // hits before vertex
-			       uint& lead_nhits_before_vtx,
-			       uint& trail_nhits_before_vtx,
-			       uint& max_nhits_before_vtx,
-			       uint& sum_nhits_before_vtx,
-			       int& delta_expected_nhits_inner,
-			       // opening angle
-			       float& delta_cot_from_Pin,
-			       // matching
-			       edm::RefToBase<reco::Track>& matched_lead,
-			       edm::RefToBase<reco::Track>& matched_trail
-			       ) const;
-
+			       ConversionInfo& info) const;
+  
   float mee(float ipx1, float ipy1, float ipz1, 
 	    float ipx2, float ipy2, float ipz2) const;
   
@@ -278,20 +285,19 @@ void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
    if (!ele.passConversionVeto()) continue;
 
    // Match to tracks in "gsfTracksOpenConversions" collection
-   edm::RefToBase<reco::Track> matched_lead;
-   edm::RefToBase<reco::Track> matched_trail;
-   bool matched = matchToConversionTracks(beamSpot,conversions,ele,matched_lead,matched_trail);
+   ConversionInfo info;
+   bool matched = matchToConversionTracks(beamSpot,conversions,ele,info);
    ele.addUserInt("isConversion", matched?1:0);
-   ele.addUserInt("convLeadTrack", matched_lead.isNonnull()?1:0);
-   ele.addUserInt("convTrailTrack", matched_trail.isNonnull()?1:0);
+   ele.addUserInt("convLeadTrack", info.matched_lead.isNonnull()?1:0);
+   ele.addUserInt("convTrailTrack", info.matched_trail.isNonnull()?1:0);
 
-   if (debug && matched) {
+   if (/*debug && */matched) {
      std::cout << "[ElectronMerger::produce]"
 	       << " event " << (evt.id()).event()
 	       << ", electron: " << iele
 	       << ", isConversion: " << (matched?1:0)
-	       << ", convLeadTrack: " << (matched_lead.isNonnull()?1:0)
-	       << ", convTrailTrack: " << (matched_trail.isNonnull()?1:0)
+	       << ", convLeadTrack: " << (info.matched_lead.isNonnull()?1:0)
+	       << ", convTrailTrack: " << (info.matched_trail.isNonnull()?1:0)
 	       << std::endl;
    }
 
@@ -382,85 +388,15 @@ void ElectronMerger::produce(edm::StreamID, edm::Event &evt, edm::EventSetup con
 
 bool ElectronMerger::matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
 					     const edm::Handle<edm::View<reco::Conversion> >& conversions,
-					     const pat::Electron& ele,
-					     edm::RefToBase<reco::Track>& matched_lead,
-					     edm::RefToBase<reco::Track>& matched_trail
-					     ) const {
-
-  // quality
-  bool valid = false;
-  float chi2prob = -1.;
-  bool quality_high_purity = false;
-  bool quality_high_efficiency = false;
-  // tracks
-  uint ntracks = 0;
-  float min_trk_pt = -1.;
-  int ilead = -1;
-  int itrail = -1;
-  // displacement
-  float l_xy = -1.;
-  float vtx_radius = -1.;
-  // invariant mass
-  float mass_from_conv = -1.;
-  float mass_from_Pin = -1.;
-  float mass_before_fit = -1.;
-  float mass_after_fit = -1.;
-  // hits before vertex
-  uint lead_nhits_before_vtx = 0;
-  uint trail_nhits_before_vtx = 0;
-  uint max_nhits_before_vtx = 0;
-  uint sum_nhits_before_vtx = 0;
-  int delta_expected_nhits_inner = 0;
-  // opening angle
-  float delta_cot_from_Pin = -1.;
-
-  return matchToConversionTracks(beamSpot,conversions,ele, //
-				 valid,chi2prob,quality_high_purity,quality_high_efficiency, // quality
-				 ntracks,min_trk_pt,ilead,itrail, // tracks
-				 l_xy,vtx_radius, // displacement
-				 mass_from_conv,mass_from_Pin,mass_before_fit,mass_after_fit, // invariant mass
-				 lead_nhits_before_vtx,trail_nhits_before_vtx, // ...
-				 max_nhits_before_vtx,sum_nhits_before_vtx, // ...
-				 delta_expected_nhits_inner, // hits before vertex
-				 delta_cot_from_Pin, // opening angle
-				 matched_lead,matched_trail // matching
-				 );
-
+					     const pat::Electron& ele) const {
+  ConversionInfo info;
+  return matchToConversionTracks(beamSpot,conversions,ele,info);
 }
 
 bool ElectronMerger::matchToConversionTracks(const edm::Handle<reco::BeamSpot>& beamSpot,
 					     const edm::Handle<edm::View<reco::Conversion> >& conversions,
 					     const pat::Electron& ele,
-					     // quality
-					     bool& valid,
-					     float& chi2prob,
-					     bool& quality_high_purity,
-					     bool& quality_high_efficiency,
-					     // tracks
-					     uint& ntracks,
-					     float& min_trk_pt,
-					     int& ilead,
-					     int& itrail,
-					     // displacement
-					     float& l_xy,
-					     float& vtx_radius,
-					     // invariant mass
-					     float& mass_from_conv,
-					     float& mass_from_Pin,
-					     float& mass_before_fit,
-					     float& mass_after_fit,
-					     // hits before vertex
-					     uint& lead_nhits_before_vtx,
-					     uint& trail_nhits_before_vtx,
-					     uint& max_nhits_before_vtx,
-					     uint& sum_nhits_before_vtx,
-					     int& delta_expected_nhits_inner,
-					     // opening angle
-					     float& delta_cot_from_Pin,
-					     // matching
-					     edm::RefToBase<reco::Track>& matched_lead,
-					     edm::RefToBase<reco::Track>& matched_trail
-					     ) const {
+					     ConversionInfo& info) const {
   
   bool matched = false;
 
@@ -483,82 +419,77 @@ bool ElectronMerger::matchToConversionTracks(const edm::Handle<reco::BeamSpot>& 
     if ( conv.tracks().size() != 2 ) { continue; }
 
     // Quality
-    valid = conv.conversionVertex().isValid(); // (=true)
-    chi2prob = ChiSquaredProbability(conv.conversionVertex().chi2(),conv.conversionVertex().ndof()); // (<0.005)
-    quality_high_purity = conv.quality(reco::Conversion::highPurity); // (=true)
-    quality_high_efficiency = conv.quality(reco::Conversion::highEfficiency); // (none)
+    info.valid = conv.conversionVertex().isValid(); // (=true)
+    info.chi2prob = ChiSquaredProbability(conv.conversionVertex().chi2(),conv.conversionVertex().ndof()); // (<0.005)
+    info.quality_high_purity = conv.quality(reco::Conversion::highPurity); // (=true)
+    info.quality_high_efficiency = conv.quality(reco::Conversion::highEfficiency); // (none)
 
     // Tracks
-    ntracks = conv.tracks().size(); // (=2)
-    min_trk_pt = -1.; // (>0.5)
+    info.ntracks = conv.tracks().size(); // (=2)
+    info.min_trk_pt = -1.; // (>0.5)
     for ( const auto& trk : conv.tracks() ) {
-      if ( min_trk_pt < 0. || trk->pt() < min_trk_pt ) { min_trk_pt = trk->pt(); }
+      if ( info.min_trk_pt < 0. || trk->pt() < info.min_trk_pt ) { info.min_trk_pt = trk->pt(); }
     }
-    ilead = -1; itrail = -1;
+    info.ilead = -1; info.itrail = -1;
     if ( conv.tracks().size() == 2 ) {
       edm::RefToBase<reco::Track> trk1 = conv.tracks().front();
       edm::RefToBase<reco::Track> trk2 = conv.tracks().back();
-      if      ( trk1->pt() > trk2->pt() ) { ilead = 0; itrail = 1; }
-      else if ( trk1->pt() < trk2->pt() ) { ilead = 1; itrail = 0; }
+      if      ( trk1->pt() > trk2->pt() ) { info.ilead = 0; info.itrail = 1; }
+      else if ( trk1->pt() < trk2->pt() ) { info.ilead = 1; info.itrail = 0; }
     }
 
     // Transverse displacement (with respect to beamspot) and vertex radius
     math::XYZVectorF p_refitted =  conv.refittedPairMomentum();
     float dx = conv.conversionVertex().x() - beamSpot->x0();
     float dy = conv.conversionVertex().y() - beamSpot->y0();
-    l_xy = (p_refitted.x()*dx + p_refitted.y()*dy) / p_refitted.rho();
-    vtx_radius = sqrt(conv.conversionVertex().position().perp2()); // (1.5<r<4.)
+    info.l_xy = (p_refitted.x()*dx + p_refitted.y()*dy) / p_refitted.rho();
+    info.vtx_radius = sqrt(conv.conversionVertex().position().perp2()); // (1.5<r<4.)
 
     // invariant mass from track pair from conversion
-    mass_from_conv = conv.pairInvariantMass();
+    info.mass_from_conv = conv.pairInvariantMass();
     
     // Invariant mass from Pin before fit to common vertex 
-    mass_from_Pin = -1.;
     if ( conv.tracksPin().size() >= 2 ) {
-      math::XYZVectorF lead_Pin = conv.tracksPin().at(ilead);
-      math::XYZVectorF trail_Pin = conv.tracksPin().at(itrail);
-      mass_from_Pin = mee( lead_Pin.x(), lead_Pin.y(), lead_Pin.z(),
-			   trail_Pin.x(), trail_Pin.y(), trail_Pin.z() );
+      math::XYZVectorF lead_Pin = conv.tracksPin().at(info.ilead);
+      math::XYZVectorF trail_Pin = conv.tracksPin().at(info.itrail);
+      info.mass_from_Pin = mee( lead_Pin.x(), lead_Pin.y(), lead_Pin.z(),
+				trail_Pin.x(), trail_Pin.y(), trail_Pin.z() );
       // Opening angle
-      delta_cot_from_Pin = 1. / tan(trail_Pin.theta()) - 1. / tan(lead_Pin.theta());
+      info.delta_cot_from_Pin = 1. / tan(trail_Pin.theta()) - 1. / tan(lead_Pin.theta());
     }
 
     // Invariant mass before fit to common vertex
-    mass_before_fit = -1.;
     if ( conv.tracks().size() >= 2 ) {
-      edm::RefToBase<reco::Track> lead_before_vtx_fit = conv.tracks().at(ilead);
-      edm::RefToBase<reco::Track> trail_before_vtx_fit = conv.tracks().at(itrail);
-      mass_before_fit = mee( lead_before_vtx_fit->px(), lead_before_vtx_fit->py(), lead_before_vtx_fit->pz(),
-			     trail_before_vtx_fit->px(), trail_before_vtx_fit->py(), trail_before_vtx_fit->pz() );
+      edm::RefToBase<reco::Track> lead_before_vtx_fit = conv.tracks().at(info.ilead);
+      edm::RefToBase<reco::Track> trail_before_vtx_fit = conv.tracks().at(info.itrail);
+      info.mass_before_fit = mee( lead_before_vtx_fit->px(), lead_before_vtx_fit->py(), lead_before_vtx_fit->pz(),
+				  trail_before_vtx_fit->px(), trail_before_vtx_fit->py(), trail_before_vtx_fit->pz() );
     }
 
     // Invariant mass after the fit to common vertex
-    mass_after_fit = -1.;
     if ( conv.conversionVertex().refittedTracks().size() >=2 ) {
-      const reco::Track lead_after_vtx_fit = conv.conversionVertex().refittedTracks().at(ilead);
-      const reco::Track trail_after_vtx_fit = conv.conversionVertex().refittedTracks().at(itrail);
-      mass_after_fit = mee( lead_after_vtx_fit.px(), lead_after_vtx_fit.py(), lead_after_vtx_fit.pz(),
-			    trail_after_vtx_fit.px(), trail_after_vtx_fit.py(), trail_after_vtx_fit.pz());
+      const reco::Track lead_after_vtx_fit = conv.conversionVertex().refittedTracks().at(info.ilead);
+      const reco::Track trail_after_vtx_fit = conv.conversionVertex().refittedTracks().at(info.itrail);
+      info.mass_after_fit = mee( lead_after_vtx_fit.px(), lead_after_vtx_fit.py(), lead_after_vtx_fit.pz(),
+				 trail_after_vtx_fit.px(), trail_after_vtx_fit.py(), trail_after_vtx_fit.pz());
       // Difference in expeted hits
-      delta_expected_nhits_inner =
+      info.delta_expected_nhits_inner =
 	lead_after_vtx_fit.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS)
 	- trail_after_vtx_fit.hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
     }
     
     // Hits prior to vertex
-    lead_nhits_before_vtx  = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(ilead) : 0;
-    trail_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(itrail) : 0;
-    max_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
+    info.lead_nhits_before_vtx  = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(info.ilead) : 0;
+    info.trail_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ? conv.nHitsBeforeVtx().at(info.itrail) : 0;
+    info.max_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
       ( conv.nHitsBeforeVtx().at(0) > conv.nHitsBeforeVtx().at(1) ?
 	conv.nHitsBeforeVtx().at(0) :
 	conv.nHitsBeforeVtx().at(1) ) : 0;
-    sum_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
+    info.sum_nhits_before_vtx = conv.nHitsBeforeVtx().size() > 1 ?
       conv.nHitsBeforeVtx().at(0) +
       conv.nHitsBeforeVtx().at(1) : 0;
     
     // Attempt to match conversion track to electron
-    matched_lead = edm::RefToBase<reco::Track>();
-    matched_trail = edm::RefToBase<reco::Track>();
     for ( uint itrk = 0; itrk < conv.tracks().size(); ++itrk ) {
 
       edm::RefToBase<reco::Track> trk = conv.tracks()[itrk];
@@ -568,12 +499,12 @@ bool ElectronMerger::matchToConversionTracks(const edm::Handle<reco::BeamSpot>& 
       if ( gsf.isNull() ) { continue; }
 
       if ( gsf.id() == trk.id() && gsf.key() == trk.key() )  { 
-	if ( (int)itrk == ilead ) {
-	  matched_lead = trk;
+	if ( (int)itrk == info.ilead ) {
+	  info.matched_lead = trk;
 	  matched = true;
 	}
-	if ( (int)itrk == itrail ) {
-	  matched_trail = trk;
+	if ( (int)itrk == info.itrail ) {
+	  info.matched_trail = trk;
 	  matched = true;
 	}
       }

--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -221,6 +221,9 @@ electronsForAnalysis = cms.EDProducer(
   useGsfModeForP4 = cms.bool(False),
   sortOutputCollections = cms.bool(True),
   saveLowPtE = cms.bool(True),
+  # conversions
+  conversions = cms.InputTag('gsfTracksOpenConversions:gsfTracksOpenConversions'),
+  beamSpot = cms.InputTag("offlineBeamSpot"),
 )
 
 electronBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",

--- a/BParkingNano/python/electronsBPark_cff.py
+++ b/BParkingNano/python/electronsBPark_cff.py
@@ -221,9 +221,10 @@ electronsForAnalysis = cms.EDProducer(
   useGsfModeForP4 = cms.bool(False),
   sortOutputCollections = cms.bool(True),
   saveLowPtE = cms.bool(True),
-  # conversions
-  conversions = cms.InputTag('gsfTracksOpenConversions:gsfTracksOpenConversions'),
-  beamSpot = cms.InputTag("offlineBeamSpot"),
+    # conversions
+    conversions = cms.InputTag('gsfTracksOpenConversions:gsfTracksOpenConversions'),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    addUserVarsExtra = cms.bool(True),
 )
 
 electronBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
@@ -262,11 +263,40 @@ electronBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         pfmvaId = Var("userFloat('pfmvaId')",float,doc="MVA ID for pfEle, 20 for low pT"),
         fBrem = Var("fbrem()",float,doc="brem fraction from the gsf fit",precision=12),
         isPFoverlap = Var("userInt('isPFoverlap')",bool,doc="flag lowPt ele overlapping with pf in selected_pf_collection",precision=8),
+        convOpen = Var("userInt('convOpen')",bool,doc="Matched to a conversion in gsfTracksOpenConversions collection"),
+        convLoose = Var("userInt('convLoose')",bool,doc="Matched to a conversion satisfying Loose WP (see code)"),
+        convTight = Var("userInt('convTight')",bool,doc="Matched to a conversion satisfying Tight WP (see code)"),
+        convLead = Var("userInt('convLead')",bool,doc="Matched to leading track from conversion"),
+        convTrail = Var("userInt('convTrail')",bool,doc="Matched to trailing track from conversion"),
+        convExtra = Var("userInt('convExtra')",bool,doc="Flag to indicate if all conversion variables are stored"),
         )
 )
 
-
-
+if electronsForAnalysis.addUserVarsExtra : 
+    electronBParkTable.variables = cms.PSet(
+        electronBParkTable.variables,
+        convValid = Var("userInt('convValid')",bool,doc="Valid conversion"),
+        convChi2Prob = Var("userFloat('convChi2Prob')",float,doc="Reduced chi2 for conversion vertex fit"),
+        convQualityHighPurity = Var("userInt('convQualityHighPurity')",bool,doc="'High purity' quality flag for conversion"),
+        convQualityHighEff = Var("userInt('convQualityHighEff')",bool,doc="'High efficiency' quality flag for conversion"),
+        convTracksN = Var("userInt('convTracksN')",int,doc="Number of tracks associated with conversion"),
+        convMinTrkPt = Var("userFloat('convMinTrkPt')",float,doc="Minimum pT found for tracks associated with conversion"),
+        convLeadIdx = Var("userInt('convLeadIdx')",int,doc="Index of leading track"),
+        convTrailIdx = Var("userInt('convTrailIdx')",int,doc="Index of trailing track"),
+        convLxy = Var("userFloat('convLxy')",float,doc="Transverse position of conversion vertex"),
+        convVtxRadius = Var("userFloat('convVtxRadius')",float,doc="Radius of conversion vertex"),
+        convMass = Var("userFloat('convMass')",float,doc="Invariant mass from conversion pair"),
+        convMassFromPin = Var("userFloat('convMassFromPin')",float,doc="Invariant mass from inner momeuntum of conversion pair"),
+        convMassBeforeFit = Var("userFloat('convMassBeforeFit')",float,doc="Invariant mass from conversion pair before fit"),
+        convMassAfterFit = Var("userFloat('convMassAfterFit')",float,doc="Invariant mass from conversion pair after fit"),
+        convLeadNHitsBeforeVtx = Var("userInt('convLeadNHitsBeforeVtx')",int,doc="Number of hits before vertex for lead track"),
+        convTrailNHitsBeforeVtx = Var("userInt('convTrailNHitsBeforeVtx')",int,doc="Number of hits before vertex for trail track"),
+        convMaxNHitsBeforeVtx = Var("userInt('convMaxNHitsBeforeVtx')",int,doc="Maximum number of hits per track before vertex"),
+        convSumNHitsBeforeVtx = Var("userInt('convSumNHitsBeforeVtx')",int,doc="Summed number of hits over tracks before vertex"),
+        convDeltaExpectedNHitsInner = Var("userInt('convDeltaExpectedNHitsInner')",int,doc="Delta number of expected hits before vertex"),
+        convDeltaCotFromPin = Var("userFloat('convDeltaCotFromPin')",float,doc="Delta cotangent theta from inner momenta"),
+    )
+    
 electronsBParkMCMatchForTable = cms.EDProducer("MCMatcher",  # cut on deltaR, deltaPt/Pt; pick best by deltaR
     src         = electronBParkTable.src,                 # final reco collection
     matched     = cms.InputTag("finalGenParticlesBPark"), # final mc-truth particle collection


### PR DESCRIPTION
This PR is based on code in Nancy's ConversionSelector RR, https://github.com/CMSBParking/BParkingNANO/pull/84.

- the main developments are in a new ConversionInfo class, which is used in the ElectronMerger module,
- pat::Electrons are matched to reco::Conversions from the gsfTracksOpenConversions collection, 
- flags are stored in the electronBPark table to indicate if each electron is matched to a conversion, which may satisfy various WPs (open, loose, tight),
- several "raw" variables are also stored in the electronBPark table if a boolean configurable is set, which may be used to apply additional/tuned selections to the conversion candidates.

*Please check carefully on the logic and comment if necessary!*

@gkaratha @amartelli @nancymarinelli @ottolau @crovelli 