### PR TITLE
New hlt reco muon matching process

### DIFF
--- a/BParkingNano/python/muonsBPark_cff.py
+++ b/BParkingNano/python/muonsBPark_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 
 
+Path=["HLT_Mu7_IP4","HLT_Mu8_IP6","HLT_Mu8_IP5","HLT_Mu8_IP3","HLT_Mu8p5_IP3p5","HLT_Mu9_IP6","HLT_Mu9_IP5","HLT_Mu9_IP4","HLT_Mu10p5_IP3p5","HLT_Mu12_IP6"]
 
 muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
                                  muonCollection = cms.InputTag("slimmedMuons"), #same collection as in NanoAOD                                                           
@@ -19,9 +20,11 @@ muonTrgSelector = cms.EDProducer("MuonTriggerSelector",
                                  ptMin = cms.double(0.5),
                                  absEtaMax = cms.double(2.4),
                                  # keeps only muons with at soft Quality flag
-                                 softMuonsOnly = cms.bool(False)
+                                 softMuonsOnly = cms.bool(False),
+                                 HLTPaths=cms.vstring(Path)#, ### comma to the softMuonsOnly
+#				 L1seeds=cms.vstring(Seed)
                              )
-
+#cuts minimun number in B both mu and e, min number of trg, dz muon, dz and dr track, 
 countTrgMuons = cms.EDFilter("PATCandViewCountFilter",
     minNumber = cms.uint32(1),
     maxNumber = cms.uint32(999999),
@@ -70,7 +73,21 @@ muonBParkTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 #        multiIsoId = Var("?passed('MultiIsoMedium')?2:passed('MultiIsoLoose')","uint8",doc="MultiIsoId from miniAOD selector (1=MultiIsoLoose, 2=MultiIsoMedium)"),
         triggerIdLoose = Var("passed('TriggerIdLoose')",bool,doc="TriggerIdLoose ID"),
 #        inTimeMuon = Var("passed('InTimeMuon')",bool,doc="inTimeMuon ID"),
-        isTriggering = Var("userInt('isTriggering')", int,doc="flag the reco muon is also triggering")
+        isTriggering = Var("userInt('isTriggering')", int,doc="flag the reco muon is also triggering"),#########################################################3,
+#        toWhichHLTisMatched = Var("userInt('ToWhichHLTisMatched')",int,doc="To which HLT muons is the reco muon matched, -1 for probe" ),
+        matched_dr = Var("userFloat('DR')",float,doc="dr with the matched triggering muon" ),
+        matched_dpt = Var("userFloat('DPT')",float,doc="dpt/pt with the matched triggering muon" ),        #comma
+        looseId = Var("userInt('looseId')",int,doc="reco muon is Loose"),
+        fired_HLT_Mu7_IP4 = Var("userInt('HLT_Mu7_IP4')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu8_IP6 = Var("userInt('HLT_Mu8_IP6')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu8_IP5 = Var("userInt('HLT_Mu8_IP5')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu8_IP3 = Var("userInt('HLT_Mu8_IP3')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu8p5_IP3p5 = Var("userInt('HLT_Mu8p5_IP3p5')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu9_IP6 = Var("userInt('HLT_Mu9_IP6')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu9_IP5 = Var("userInt('HLT_Mu9_IP5')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu9_IP4 = Var("userInt('HLT_Mu9_IP4')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu10p5_IP3p5 = Var("userInt('HLT_Mu10p5_IP3p5')",int,doc="reco muon fired this trigger"),
+        fired_HLT_Mu12_IP6 = Var("userInt('HLT_Mu12_IP6')",int,doc="reco muon fired this trigger")#,
     ),
 )
 
@@ -102,19 +119,21 @@ selectedMuonsMCMatchEmbedded = cms.EDProducer(
     matching = cms.InputTag('muonsBParkMCMatchForTable')
 )
 
+
 muonTriggerMatchedTable = muonBParkTable.clone(
     src = cms.InputTag("muonTrgSelector:trgMuons"),
     name = cms.string("TriggerMuon"),
-    doc  = cms.string("reco muon matched to triggering muon"),
+    doc  = cms.string("HLT Muons matched with reco muons"), #reco muon matched to triggering muon"),
     variables = cms.PSet(CandVars,
         vx = Var("vx()",float,doc="x coordinate of vertex position, in cm",precision=6),
         vy = Var("vy()",float,doc="y coordinate of vertex position, in cm",precision=6),
-        vz = Var("vz()",float,doc="z coordinate of vertex position, in cm",precision=6),
-        trgMuonIndex = Var("userInt('trgMuonIndex')", int,doc="index in trigger muon collection")
+        vz = Var("vz()",float,doc="z coordinate of vertex position, in cm",precision=6)####################,
+#        trgMuonIndex = Var("userInt('trgMuonIndex')", int,doc="index in trigger muon collection")
    )
 )
+
 
 muonBParkSequence = cms.Sequence(muonTrgSelector * countTrgMuons)
 muonBParkMC = cms.Sequence(muonBParkSequence + muonsBParkMCMatchForTable + selectedMuonsMCMatchEmbedded + muonBParkMCTable)
 muonBParkTables = cms.Sequence(muonBParkTable)
-muonTriggerMatchedTables = cms.Sequence(muonTriggerMatchedTable)
+muonTriggerMatchedTables = cms.Sequence(muonTriggerMatchedTable)   ####

--- a/BParkingNano/python/nanoBPark_cff.py
+++ b/BParkingNano/python/nanoBPark_cff.py
@@ -37,7 +37,7 @@ nanoSequenceMC = cms.Sequence(particleLevelBParkSequence + genParticleBParkSeque
 
 
 def nanoAOD_customizeMuonTriggerBPark(process):
-    process.nanoSequence = cms.Sequence( process.nanoSequence + muonBParkSequence + muonTriggerMatchedTables + muonBParkTables)
+    process.nanoSequence = cms.Sequence( process.nanoSequence + muonBParkSequence + muonBParkTables)#+ muonTriggerMatchedTables)   ###comment in this extra table in case you want to create the TriggerMuon collection again.
     return process
 
 def nanoAOD_customizeTrackFilteredBPark(process):


### PR DESCRIPTION
There have to exist a few relics from the previous code (like the minimum DR in muonBPark_cff.py). However all these relics do not affect the new matching process between the HLT and the reco muons. 
The new matching process is based on CMSSW functions without making a new DR matching. No ID is required for the reco muon. In case there are many different reco muons matching the same HLT object, or one reco muon matches different HLT objects only the pair with the minimum dR is considered as the correct one and only the reco muon from the specific pair is labelled as TAG muon. A reco muon that is matched with an HLT object can be found by demanding Muon_isTriggering[mu]==1. 
Also, we now know if a reco muon fired a specific HLT path or not. 
There is minor change in nanoBPark_cff.py in order not to save twice the reco muons that are labelled as triggering muons. 

 